### PR TITLE
fix: compilation for single-symbol repeat predicates over Vec<Propert…

### DIFF
--- a/examples/src/three-repeats/Cargo.toml
+++ b/examples/src/three-repeats/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "three-repeats"
+version = "0.10.10"
+edition = "2021"
+default-run = "run"
+
+[dependencies]
+pax-lang = { version = "0.10.10" }
+pax-std = { version = "0.10.10" }
+pax-compiler = { version = "0.10.10", optional = true }
+pax-manifest = { version = "0.10.10", optional = true }
+serde_json = {version = "1.0.95", optional = true}
+
+[[bin]]
+name = "parser"
+path = "src/lib.rs"
+required-features = ["parser"]
+
+[[bin]]
+name = "run"
+path = "bin/run.rs"
+
+[features]
+parser = ["pax-std/parser", "pax-lang/parser", "dep:serde_json", "dep:pax-compiler", "dep:pax-manifest"]

--- a/examples/src/three-repeats/bin/run.rs
+++ b/examples/src/three-repeats/bin/run.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    let pax_args = {
+        let mut extended_args = vec!["run"];
+        extended_args.extend(args.iter().map(|arg| arg.as_str()));
+        extended_args
+    };
+
+    let current_dir = env::current_dir().expect("Failed to get current directory");
+
+    let status = Command::new("./pax")
+        .args(&pax_args)
+        .current_dir(current_dir)
+        .status()
+        .expect("Failed to execute pax-cli");
+
+    std::process::exit(status.code().unwrap_or(1));
+}

--- a/examples/src/three-repeats/pax
+++ b/examples/src/three-repeats/pax
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+### Helper script for pax libdev, allowing pax-cli-like ergonomics inside the pax-example directory
+###
+### For example, from @/pax root:
+### `cd pax-example && ./pax run --target=macos`
+### `cd pax-example && ./pax parse`
+### `cd pax-example && ./pax libdev build-chassis`
+
+set -e
+current_dir=$(pwd)
+pushd ../../../pax-cli
+cargo build
+../target/debug/pax-cli "$@" --path="$current_dir" --libdev
+popd

--- a/examples/src/three-repeats/src/lib.pax
+++ b/examples/src/three-repeats/src/lib.pax
@@ -1,0 +1,11 @@
+for i in 0..5 {
+    <Rectangle width=100px height=100px x={(i * 150)px} y=50px />
+}
+
+for datum in self.some_data {
+    <Rectangle width=100px height=100px x={(datum.x)px} y=150px />
+}
+
+for (datum, i) in self.some_data {
+    <Rectangle width=100px height=100px x={(datum.x)px} y={(250 + i * 20)px} />
+}

--- a/examples/src/three-repeats/src/lib.rs
+++ b/examples/src/three-repeats/src/lib.rs
@@ -1,0 +1,47 @@
+#![allow(unused_imports)]
+
+use pax_lang::*;
+use pax_lang::api::*;
+use pax_std::primitives::*;
+use pax_std::types::*;
+use pax_std::types::text::*;
+use pax_std::components::*;
+use pax_std::components::Stacker;
+
+#[derive(Pax)]
+#[main]
+#[custom(Default)]
+#[file("lib.pax")]
+pub struct ThreeRepeats {
+    pub some_data: Property<Vec<CustomStruct>>,
+}
+
+impl Default for ThreeRepeats {
+    fn default() -> Self {
+        Self {
+            some_data: Box::new(PropertyLiteral::new(vec![
+                CustomStruct{
+                    x: 250
+                },
+                CustomStruct{
+                    x: 300
+                },
+                CustomStruct{
+                    x: 450
+                },
+                CustomStruct{
+                    x: 550
+                },
+                CustomStruct{
+                    x: 850
+                }
+            ]))
+        }
+    }
+}
+
+#[derive(Pax)]
+#[custom(Imports)]
+pub struct CustomStruct {
+    pub x: isize,
+}

--- a/examples/three-repeats.rs
+++ b/examples/three-repeats.rs
@@ -1,0 +1,8 @@
+mod scripts;
+use scripts::run_example;
+
+fn main() {
+    if let Err(error) = run_example() {
+        eprintln!("Error: {}", error);
+    }
+}

--- a/pax-compiler/src/expressions.rs
+++ b/pax-compiler/src/expressions.rs
@@ -365,6 +365,38 @@ fn recurse_compile_expressions<'a>(
             //type of property `self.foo`
             let (output_statement, invocations) = compile_paxel_to_ril(paxel.clone(), &ctx)?;
 
+
+            //Figure out the return type for our datum — either `T` for `Property<Vec<T>>`, or `isize` for some range `j..k`
+            //if repeat_source is a range, this is simply isize
+            //if repeat_source is a symbolic binding, then we resolve that symbolic binding and use that resolved type here
+            let iterable_type =
+                if let Some(_) = &repeat_source_definition.range_expression_paxel {
+                    TypeDefinition::primitive("isize")
+                } else if let Some(symbolic_binding) =
+                    &repeat_source_definition.symbolic_binding
+                {
+                    let pd = ctx
+                        .resolve_symbol_as_prop_def(
+                            &symbolic_binding.token_value,
+                            symbolic_binding.clone(),
+                        )?
+                        .ok_or::<eyre::Report>(PaxTemplateError::new(
+                            Some(format!(
+                                "Property not found: {}",
+                                symbolic_binding.token_value
+                            )),
+                            symbolic_binding.clone(),
+                        ))?
+                        .last()
+                        .unwrap()
+                        .clone();
+                    pd.get_inner_iterable_type_definition(ctx.type_table)
+                        .unwrap()
+                        .clone()
+                } else {
+                    unreachable!()
+                };
+
             // Attach shadowed property symbols to the scope_stack, so e.g. `elem` can be
             // referred to with the symbol `elem` in PAXEL
             match cfa.repeat_predicate_definition.as_ref().unwrap() {
@@ -386,7 +418,7 @@ fn recurse_compile_expressions<'a>(
                             is_repeat_source_iterable,
                             is_property_wrapped: true,
                         },
-                        type_id: "isize".to_string(),
+                        type_id: iterable_type.type_id.clone(),
                     };
 
                     let scope: HashMap<String, PropertyDefinition> = HashMap::from([
@@ -398,35 +430,6 @@ fn recurse_compile_expressions<'a>(
                     ctx.scope_stack.push(scope);
                 }
                 ControlFlowRepeatPredicateDefinition::ElemIdIndexId(elem_id, index_id) => {
-                    //if repeat_source is a range, this is simply isize
-                    //if repeat_source is a symbolic binding, then we resolve that symbolic binding and use that resolved type here
-                    let iterable_type =
-                        if let Some(_) = &repeat_source_definition.range_expression_paxel {
-                            TypeDefinition::primitive("isize")
-                        } else if let Some(symbolic_binding) =
-                            &repeat_source_definition.symbolic_binding
-                        {
-                            let pd = ctx
-                                .resolve_symbol_as_prop_def(
-                                    &symbolic_binding.token_value,
-                                    symbolic_binding.clone(),
-                                )?
-                                .ok_or::<eyre::Report>(PaxTemplateError::new(
-                                    Some(format!(
-                                        "Property not found: {}",
-                                        symbolic_binding.token_value
-                                    )),
-                                    symbolic_binding.clone(),
-                                ))?
-                                .last()
-                                .unwrap()
-                                .clone();
-                            pd.get_inner_iterable_type_definition(ctx.type_table)
-                                .unwrap()
-                                .clone()
-                        } else {
-                            unreachable!()
-                        };
 
                     let elem_property_definition = PropertyDefinition {
                         name: format!("{}", elem_id.token_value),
@@ -434,8 +437,8 @@ fn recurse_compile_expressions<'a>(
                         flags: PropertyDefinitionFlags {
                             is_binding_repeat_elem: true,
                             is_binding_repeat_i: false,
-                            is_repeat_source_range,
-                            is_repeat_source_iterable,
+                            is_repeat_source_range: is_repeat_source_range.clone(),
+                            is_repeat_source_iterable: is_repeat_source_iterable.clone(),
                             is_property_wrapped: true,
                         },
                     };

--- a/pax-compiler/src/expressions.rs
+++ b/pax-compiler/src/expressions.rs
@@ -365,37 +365,33 @@ fn recurse_compile_expressions<'a>(
             //type of property `self.foo`
             let (output_statement, invocations) = compile_paxel_to_ril(paxel.clone(), &ctx)?;
 
-
             //Figure out the return type for our datum — either `T` for `Property<Vec<T>>`, or `isize` for some range `j..k`
             //if repeat_source is a range, this is simply isize
             //if repeat_source is a symbolic binding, then we resolve that symbolic binding and use that resolved type here
-            let iterable_type =
-                if let Some(_) = &repeat_source_definition.range_expression_paxel {
-                    TypeDefinition::primitive("isize")
-                } else if let Some(symbolic_binding) =
-                    &repeat_source_definition.symbolic_binding
-                {
-                    let pd = ctx
-                        .resolve_symbol_as_prop_def(
-                            &symbolic_binding.token_value,
-                            symbolic_binding.clone(),
-                        )?
-                        .ok_or::<eyre::Report>(PaxTemplateError::new(
-                            Some(format!(
-                                "Property not found: {}",
-                                symbolic_binding.token_value
-                            )),
-                            symbolic_binding.clone(),
-                        ))?
-                        .last()
-                        .unwrap()
-                        .clone();
-                    pd.get_inner_iterable_type_definition(ctx.type_table)
-                        .unwrap()
-                        .clone()
-                } else {
-                    unreachable!()
-                };
+            let iterable_type = if let Some(_) = &repeat_source_definition.range_expression_paxel {
+                TypeDefinition::primitive("isize")
+            } else if let Some(symbolic_binding) = &repeat_source_definition.symbolic_binding {
+                let pd = ctx
+                    .resolve_symbol_as_prop_def(
+                        &symbolic_binding.token_value,
+                        symbolic_binding.clone(),
+                    )?
+                    .ok_or::<eyre::Report>(PaxTemplateError::new(
+                        Some(format!(
+                            "Property not found: {}",
+                            symbolic_binding.token_value
+                        )),
+                        symbolic_binding.clone(),
+                    ))?
+                    .last()
+                    .unwrap()
+                    .clone();
+                pd.get_inner_iterable_type_definition(ctx.type_table)
+                    .unwrap()
+                    .clone()
+            } else {
+                unreachable!()
+            };
 
             // Attach shadowed property symbols to the scope_stack, so e.g. `elem` can be
             // referred to with the symbol `elem` in PAXEL
@@ -430,7 +426,6 @@ fn recurse_compile_expressions<'a>(
                     ctx.scope_stack.push(scope);
                 }
                 ControlFlowRepeatPredicateDefinition::ElemIdIndexId(elem_id, index_id) => {
-
                     let elem_property_definition = PropertyDefinition {
                         name: format!("{}", elem_id.token_value),
                         type_id: iterable_type.type_id,


### PR DESCRIPTION
…y<T>>, like for elem in self.some_elems

Also added simple test `three-repeats` case that renders a smattering of blue rectangles.  Prior to this fix, that example failed to compile.