### PR TITLE
Ss/for flicker

### DIFF
--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -133,12 +133,7 @@ pub extern "C" fn pax_interrupt(
                 let ptr = ref_args.image_data as *const u8;
                 let slice = unsafe { std::slice::from_raw_parts(ptr, ref_args.image_data_length) };
                 let owned_data: Vec<u8> = slice.to_vec();
-                engine.load_image(
-                    ref_args.id_chain,
-                    owned_data,
-                    ref_args.width,
-                    ref_args.height,
-                );
+                engine.load_image(&ref_args.path, owned_data, ref_args.width, ref_args.height);
             }
             ImageLoadInterruptArgs::Data(_) => {}
         },

--- a/pax-chassis-web/interface/src/classes/native-element-pool.ts
+++ b/pax-chassis-web/interface/src/classes/native-element-pool.ts
@@ -564,6 +564,7 @@ export class NativeElementPool {
             "Image": {
                 "Data": {
                     "id_chain": patch.id_chain!,
+                    "path": patch.path!,
                     "width": image_data.width,
                     "height": image_data.height,
                 }

--- a/pax-chassis-web/interface/src/classes/native-element-pool.ts
+++ b/pax-chassis-web/interface/src/classes/native-element-pool.ts
@@ -71,6 +71,7 @@ export class NativeElementPool {
         });
     }
 
+
     sendScrollerValues(){
         this.scrollers.forEach((scroller, id) => {
             // @ts-ignore
@@ -543,6 +544,9 @@ export class NativeElementPool {
 
     async imageLoad(patch: ImageLoadPatch, chassis: PaxChassisWeb) {
 
+        if (chassis.image_loaded(patch.path)) {
+            return
+        }
         //Check the full path of our index.js; use the prefix of this path also for our image assets
         function getScriptBasePath(scriptName: string) {
             const scripts = document.getElementsByTagName('script');

--- a/pax-chassis-web/interface/src/classes/occlusion-context.ts
+++ b/pax-chassis-web/interface/src/classes/occlusion-context.ts
@@ -13,7 +13,6 @@ export class OcclusionContext {
     private scrollerId?: number[];
     private objectManager: ObjectManager;
     private chassis?: PaxChassisWeb;
-    private hidden_native_layers = false;
 
     constructor(objectManager: ObjectManager) {
         this.objectManager = objectManager;
@@ -27,33 +26,6 @@ export class OcclusionContext {
         this.chassis = chassis;
         this.canvasMap = canvasMap;
         this.growTo(0);
-    }
-
-    // Done to not trigger reflows on each native element update
-    hideNativeLayers() {
-        this.hidden_native_layers = true;
-        if (this.layers) {
-            for(let i = 0; i <= this.layers!.length; i++) {
-                if (this.layers[i]) {
-                    if (this.layers![i].native) {
-                        this.layers![i].native!.hidden = true;
-                    }
-                }
-            }
-        }
-    }
-
-    showNativeLayers() {
-        this.hidden_native_layers = false;
-        if (this.layers) {
-            for(let i = 0; i <= this.layers!.length; i++) {
-                if (this.layers[i]) {
-                    if (this.layers![i].native) {
-                        this.layers![i].native!.hidden = false;
-                    }
-                }
-            }
-        }
     }
 
     growTo(z_index: number) {

--- a/pax-chassis-web/interface/src/classes/occlusion-context.ts
+++ b/pax-chassis-web/interface/src/classes/occlusion-context.ts
@@ -13,6 +13,7 @@ export class OcclusionContext {
     private scrollerId?: number[];
     private objectManager: ObjectManager;
     private chassis?: PaxChassisWeb;
+    private hidden_native_layers = false;
 
     constructor(objectManager: ObjectManager) {
         this.objectManager = objectManager;
@@ -26,6 +27,33 @@ export class OcclusionContext {
         this.chassis = chassis;
         this.canvasMap = canvasMap;
         this.growTo(0);
+    }
+
+    // Done to not trigger reflows on each native element update
+    hideNativeLayers() {
+        this.hidden_native_layers = true;
+        if (this.layers) {
+            for(let i = 0; i <= this.layers!.length; i++) {
+                if (this.layers[i]) {
+                    if (this.layers![i].native) {
+                        this.layers![i].native!.hidden = true;
+                    }
+                }
+            }
+        }
+    }
+
+    showNativeLayers() {
+        this.hidden_native_layers = false;
+        if (this.layers) {
+            for(let i = 0; i <= this.layers!.length; i++) {
+                if (this.layers[i]) {
+                    if (this.layers![i].native) {
+                        this.layers![i].native!.hidden = false;
+                    }
+                }
+            }
+        }
     }
 
     growTo(z_index: number) {

--- a/pax-chassis-web/interface/src/index.ts
+++ b/pax-chassis-web/interface/src/index.ts
@@ -107,8 +107,11 @@ function renderLoop (chassis: PaxChassisWeb, mount: Element, get_latest_memory: 
         setupEventListeners(chassis, mount);
         initializedChassis = true;
     }
+
+    nativePool.baseOcclusionContext.hideNativeLayers();
     //@ts-ignore
     processMessages(messages, chassis, objectManager);
+    nativePool.baseOcclusionContext.showNativeLayers();
 
     //draw canvas elements
     chassis.render();

--- a/pax-chassis-web/interface/src/index.ts
+++ b/pax-chassis-web/interface/src/index.ts
@@ -108,10 +108,8 @@ function renderLoop (chassis: PaxChassisWeb, mount: Element, get_latest_memory: 
         initializedChassis = true;
     }
 
-    nativePool.baseOcclusionContext.hideNativeLayers();
     //@ts-ignore
     processMessages(messages, chassis, objectManager);
-    nativePool.baseOcclusionContext.showNativeLayers();
 
     //draw canvas elements
     chassis.render();

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -166,7 +166,7 @@ impl PaxChassisWeb {
                 ImageLoadInterruptArgs::Reference(_ref_args) => {}
                 ImageLoadInterruptArgs::Data(data_args) => {
                     let data = Uint8Array::new(additional_payload).to_vec();
-                    engine.load_image(data_args.id_chain, data, data_args.width, data_args.height);
+                    engine.load_image(&data_args.path, data, data_args.width, data_args.height);
                 }
             },
             NativeInterrupt::FormButtonClick(args) => {

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -63,8 +63,8 @@ pub fn wasm_memory() -> JsValue {
 
 #[wasm_bindgen]
 pub struct PaxChassisWeb {
+    drawing_contexts: Renderer<WebRenderContext<'static>>,
     engine: Rc<RefCell<PaxEngine>>,
-    drawing_contexts: HashMap<String, Box<dyn RenderContext>>,
     #[cfg(feature = "designtime")]
     designtime: Rc<RefCell<DesigntimeManager>>,
 }
@@ -97,7 +97,7 @@ impl PaxChassisWeb {
             let engine_container: Rc<RefCell<PaxEngine>> = Rc::new(RefCell::new(engine));
             Self {
                 engine: engine_container,
-                drawing_contexts: HashMap::new(),
+                drawing_contexts: Renderer::new(),
                 designtime,
             }
         }
@@ -114,7 +114,7 @@ impl PaxChassisWeb {
 
             Self {
                 engine: engine_container,
-                drawing_contexts: HashMap::new(),
+                drawing_contexts: Renderer::new(),
             }
         }
     }
@@ -142,18 +142,15 @@ impl PaxChassisWeb {
         canvas.set_height(height as u32);
         let _ = context.scale(dpr, dpr);
 
-        let render_context = Box::new(Renderer {
-            backend: WebRenderContext::new(context, window.clone()),
-        }) as Box<dyn RenderContext>;
-
-        self.drawing_contexts.insert(id, render_context);
+        let render_context = WebRenderContext::new(context, window.clone());
+        self.drawing_contexts.add_context(&id, render_context);
     }
 
     pub fn send_viewport_update(&mut self, width: f64, height: f64) {
         self.engine.borrow_mut().set_viewport_size((width, height));
     }
     pub fn remove_context(&mut self, id: String) {
-        self.drawing_contexts.remove(&id);
+        self.drawing_contexts.remove_context(&id);
     }
 
     pub fn interrupt(&mut self, native_interrupt: String, additional_payload: &JsValue) {
@@ -166,7 +163,12 @@ impl PaxChassisWeb {
                 ImageLoadInterruptArgs::Reference(_ref_args) => {}
                 ImageLoadInterruptArgs::Data(data_args) => {
                     let data = Uint8Array::new(additional_payload).to_vec();
-                    engine.load_image(&data_args.path, data, data_args.width, data_args.height);
+                    self.drawing_contexts.load_image(
+                        &data_args.path,
+                        &data,
+                        data_args.width,
+                        data_args.height,
+                    );
                 }
             },
             NativeInterrupt::FormButtonClick(args) => {
@@ -495,7 +497,13 @@ impl PaxChassisWeb {
     }
 
     pub fn render(&mut self) {
-        self.engine.borrow_mut().render(&mut self.drawing_contexts);
+        self.engine
+            .borrow_mut()
+            .render((&mut self.drawing_contexts) as &mut dyn RenderContext);
+    }
+
+    pub fn image_loaded(&mut self, path: &str) -> bool {
+        self.drawing_contexts.image_loaded(path)
     }
 }
 

--- a/pax-core/src/engine.rs
+++ b/pax-core/src/engine.rs
@@ -1,7 +1,6 @@
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::rc::Rc;
 
 use pax_message::{NativeMessage, OcclusionPatch};
@@ -13,7 +12,7 @@ use pax_runtime_api::{
     ArgsTouchStart, ArgsWheel, CommonProperties, Interpolatable, Layer, NodeContext,
     OcclusionLayerGen, RenderContext, TransitionManager,
 };
-use piet::{ImageBuf, InterpolationMode};
+use piet::InterpolationMode;
 
 use crate::declarative_macros::{handle_vtable_update, handle_vtable_update_optional};
 use crate::{
@@ -133,39 +132,87 @@ impl Default for HandlerRegistry {
     }
 }
 
-pub struct Renderer<R> {
-    pub backend: R,
+pub struct Renderer<R: piet::RenderContext> {
+    pub backends: HashMap<String, R>,
+    pub image_map: HashMap<String, R::Image>,
+}
+
+impl<R: piet::RenderContext> Renderer<R> {
+    pub fn new() -> Self {
+        Self {
+            backends: HashMap::new(),
+            image_map: HashMap::new(),
+        }
+    }
+
+    pub fn add_context(&mut self, id: &str, context: R) {
+        self.backends.insert(id.to_owned(), context);
+    }
+
+    pub fn remove_context(&mut self, id: &str) {
+        self.backends.remove(id);
+    }
+
+    pub fn image_loaded(&self, path: &str) -> bool {
+        self.image_map.contains_key(path)
+    }
 }
 
 impl<R: piet::RenderContext> pax_runtime_api::RenderContext for Renderer<R> {
-    fn fill(&mut self, path: kurbo::BezPath, brush: &piet_common::PaintBrush) {
-        self.backend.fill(path, brush);
+    fn fill(&mut self, layer: &str, path: kurbo::BezPath, brush: &piet_common::PaintBrush) {
+        self.backends.get_mut(layer).unwrap().fill(path, brush);
     }
 
-    fn stroke(&mut self, path: kurbo::BezPath, brush: &piet_common::PaintBrush, width: f64) {
-        self.backend.stroke(path, brush, width);
+    fn stroke(
+        &mut self,
+        layer: &str,
+        path: kurbo::BezPath,
+        brush: &piet_common::PaintBrush,
+        width: f64,
+    ) {
+        self.backends
+            .get_mut(layer)
+            .unwrap()
+            .stroke(path, brush, width);
     }
 
-    fn save(&mut self) {
-        self.backend.save().expect("failed to save piet state");
+    fn save(&mut self, layer: &str) {
+        self.backends
+            .get_mut(layer)
+            .unwrap()
+            .save()
+            .expect("failed to save piet state");
     }
 
-    fn clip(&mut self, path: kurbo::BezPath) {
-        self.backend.clip(path);
+    fn clip(&mut self, layer: &str, path: kurbo::BezPath) {
+        self.backends.get_mut(layer).unwrap().clip(path);
     }
 
-    fn restore(&mut self) {
-        self.backend
+    fn restore(&mut self, layer: &str) {
+        self.backends
+            .get_mut(layer)
+            .unwrap()
             .restore()
             .expect("failed to restore piet state");
     }
 
-    fn draw_image(&mut self, image: &piet::ImageBuf, rect: kurbo::Rect) {
-        // Is this expensive to do each draw? if so maybe move the image
-        // resource lookup into this rendercontext
-        let img = &image.to_image(&mut self.backend);
-        self.backend
-            .draw_image(img, rect, InterpolationMode::Bilinear)
+    fn load_image(&mut self, path: &str, buf: &[u8], width: usize, height: usize) {
+        //is this okay!? we know it's the same kind of backend no matter what layer, but it might be storing data?
+        let render_context = self.backends.values_mut().next().unwrap();
+        let img = render_context
+            .make_image(width, height, buf, piet::ImageFormat::RgbaSeparate)
+            .expect("image creation successful");
+        self.image_map.insert(path.to_owned(), img);
+    }
+
+    fn draw_image(&mut self, layer: &str, image_path: &str, rect: kurbo::Rect) {
+        let Some(img) = self.image_map.get(image_path) else {
+            return;
+        };
+        self.backends
+            .get_mut(layer)
+            .unwrap()
+            .draw_image(img, rect, InterpolationMode::Bilinear);
     }
 }
 
@@ -346,7 +393,7 @@ impl PaxEngine {
         self.runtime_context.take_native_messages()
     }
 
-    pub fn render(&mut self, rcs: &mut HashMap<String, Box<dyn RenderContext>>) {
+    pub fn render(&mut self, rcs: &mut dyn RenderContext) {
         // This is pretty useful during debugging - left it here since I use it often. /Sam
         // pax_runtime_api::log(&format!("tree: {:#?}", self.root_node));
 
@@ -413,12 +460,5 @@ impl PaxEngine {
     /// Called by chassis when viewport size changes, e.g. with native window resizes
     pub fn set_viewport_size(&mut self, new_viewport_size: (f64, f64)) {
         self.runtime_context.globals_mut().viewport.bounds = new_viewport_size;
-    }
-
-    pub fn load_image(&mut self, path: &str, image_data: Vec<u8>, width: usize, height: usize) {
-        self.runtime_context.image_map.insert(
-            path.to_owned(),
-            ImageBuf::from_raw(image_data, piet::ImageFormat::RgbaSeparate, width, height),
-        );
     }
 }

--- a/pax-core/src/engine.rs
+++ b/pax-core/src/engine.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use pax_message::{NativeMessage, OcclusionPatch};
@@ -414,15 +415,9 @@ impl PaxEngine {
         self.runtime_context.globals_mut().viewport.bounds = new_viewport_size;
     }
 
-    pub fn load_image(
-        &mut self,
-        id_chain: Vec<u32>,
-        image_data: Vec<u8>,
-        width: usize,
-        height: usize,
-    ) {
+    pub fn load_image(&mut self, path: &str, image_data: Vec<u8>, width: usize, height: usize) {
         self.runtime_context.image_map.insert(
-            id_chain,
+            path.to_owned(),
             ImageBuf::from_raw(image_data, piet::ImageFormat::RgbaSeparate, width, height),
         );
     }

--- a/pax-core/src/engine/expanded_node.rs
+++ b/pax-core/src/engine/expanded_node.rs
@@ -285,18 +285,11 @@ impl ExpandedNode {
         }
     }
 
-    pub fn recurse_render(
-        &self,
-        context: &mut RuntimeContext,
-        rcs: &mut HashMap<String, Box<dyn RenderContext>>,
-    ) {
+    pub fn recurse_render(&self, context: &mut RuntimeContext, rcs: &mut dyn RenderContext) {
         for child in self.children.borrow().iter().rev() {
             child.recurse_render(context, rcs);
         }
-        let rc = &mut rcs
-            .get_mut(&self.occlusion_id.borrow().to_string())
-            .expect("occlusion ind present");
-        self.instance_node.render(&self, context, rc);
+        self.instance_node.render(&self, context, rcs);
     }
 
     /// Manages unpacking an Rc<RefCell<dyn Any>>, downcasting into

--- a/pax-core/src/properties.rs
+++ b/pax-core/src/properties.rs
@@ -21,7 +21,7 @@ pub struct RuntimeContext {
     messages: Vec<NativeMessage>,
     globals: Globals,
     expression_table: ExpressionTable,
-    pub image_map: HashMap<Vec<u32>, ImageBuf>,
+    pub image_map: HashMap<String, ImageBuf>,
     pub lookup: HashMap<u32, Rc<ExpandedNode>>,
 }
 

--- a/pax-core/src/properties.rs
+++ b/pax-core/src/properties.rs
@@ -1,6 +1,5 @@
 use pax_message::NativeMessage;
 use pax_runtime_api::Numeric;
-use piet::ImageBuf;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::{any::Any, collections::HashMap};
@@ -21,7 +20,6 @@ pub struct RuntimeContext {
     messages: Vec<NativeMessage>,
     globals: Globals,
     expression_table: ExpressionTable,
-    pub image_map: HashMap<String, ImageBuf>,
     pub lookup: HashMap<u32, Rc<ExpandedNode>>,
 }
 
@@ -32,7 +30,6 @@ impl RuntimeContext {
             messages: Vec::new(),
             globals,
             expression_table,
-            image_map: HashMap::default(),
             lookup: HashMap::default(),
         }
     }

--- a/pax-core/src/rendering.rs
+++ b/pax-core/src/rendering.rs
@@ -231,7 +231,7 @@ pub trait InstanceNode {
         &self,
         expanded_node: &ExpandedNode,
         context: &mut RuntimeContext,
-        rcs: &mut Box<dyn RenderContext>,
+        rcs: &mut dyn RenderContext,
     ) {
         //no-op default implementation
     }
@@ -245,7 +245,7 @@ pub trait InstanceNode {
         &self,
         expanded_node: &ExpandedNode,
         context: &mut RuntimeContext,
-        rcs: &mut Box<dyn RenderContext>,
+        rcs: &mut dyn RenderContext,
     ) {
     }
 
@@ -255,11 +255,7 @@ pub trait InstanceNode {
     /// to stop clipping.
     /// Occurs in a post-order traversal of the render tree.
     #[allow(unused_variables)]
-    fn handle_post_render(
-        &self,
-        context: &mut RuntimeContext,
-        rcs: &mut HashMap<String, Box<dyn RenderContext>>,
-    ) {
+    fn handle_post_render(&self, context: &mut RuntimeContext, rcs: &mut dyn RenderContext) {
         //no-op default implementation
     }
 

--- a/pax-message/src/lib.rs
+++ b/pax-message/src/lib.rs
@@ -258,6 +258,7 @@ pub enum ImageLoadInterruptArgs {
 #[repr(C)]
 pub struct ImagePointerArgs {
     pub id_chain: Vec<u32>,
+    pub path: String,
     pub image_data: u64,
     pub image_data_length: usize,
     pub width: usize,
@@ -268,6 +269,7 @@ pub struct ImagePointerArgs {
 #[repr(C)]
 pub struct ImageDataArgs {
     pub id_chain: Vec<u32>,
+    pub path: String,
     pub width: usize,
     pub height: usize,
 }

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -1200,10 +1200,11 @@ impl From<StringBox> for String {
 }
 
 pub trait RenderContext {
-    fn fill(&mut self, path: BezPath, brush: &PaintBrush);
-    fn stroke(&mut self, path: BezPath, brush: &PaintBrush, width: f64);
-    fn save(&mut self);
-    fn restore(&mut self);
-    fn clip(&mut self, path: BezPath);
-    fn draw_image(&mut self, image: &ImageBuf, rect: Rect);
+    fn fill(&mut self, layer: &str, path: BezPath, brush: &PaintBrush);
+    fn stroke(&mut self, layer: &str, path: BezPath, brush: &PaintBrush, width: f64);
+    fn save(&mut self, layer: &str);
+    fn restore(&mut self, layer: &str);
+    fn clip(&mut self, layer: &str, path: BezPath);
+    fn load_image(&mut self, path: &str, image: &[u8], width: usize, height: usize);
+    fn draw_image(&mut self, layer: &str, image_path: &str, rect: kurbo::Rect);
 }

--- a/pax-std/pax-std-primitives/src/ellipse.rs
+++ b/pax-std/pax-std-primitives/src/ellipse.rs
@@ -35,7 +35,7 @@ impl InstanceNode for EllipseInstance {
         &self,
         expanded_node: &ExpandedNode,
         _context: &mut RuntimeContext,
-        rc: &mut Box<dyn RenderContext>,
+        rc: &mut dyn RenderContext,
     ) {
         let computed_props = expanded_node.layout_properties.borrow();
         let tab = &computed_props.as_ref().unwrap().computed_tab;
@@ -57,12 +57,14 @@ impl InstanceNode for EllipseInstance {
                 unimplemented!("gradients not supported on ellipse")
             };
 
-            rc.fill(transformed_bez_path, &color.into());
+            let layer_id = format!("{}", expanded_node.occlusion_id.borrow());
+            rc.fill(&layer_id, transformed_bez_path, &color.into());
 
             //hack to address "phantom stroke" bug on Web
             let width: f64 = *&properties.stroke.get().width.get().into();
             if width > f64::EPSILON {
                 rc.stroke(
+                    &layer_id,
                     duplicate_transformed_bez_path,
                     &properties.stroke.get().color.get().to_piet_color().into(),
                     width,

--- a/pax-std/pax-std-primitives/src/frame.rs
+++ b/pax-std/pax-std-primitives/src/frame.rs
@@ -108,7 +108,7 @@ impl InstanceNode for FrameInstance {
         &self,
         _expanded_node: &ExpandedNode,
         _context: &mut RuntimeContext,
-        _rc: &mut Box<dyn RenderContext>,
+        _rc: &mut dyn RenderContext,
     ) {
         // let tab = &expanded_node.computed_tab.as_ref().unwrap();
 
@@ -133,11 +133,7 @@ impl InstanceNode for FrameInstance {
         // }
     }
 
-    fn handle_post_render(
-        &self,
-        _context: &mut RuntimeContext,
-        _rcs: &mut HashMap<String, Box<dyn RenderContext>>,
-    ) {
+    fn handle_post_render(&self, _context: &mut RuntimeContext, _rcs: &mut dyn RenderContext) {
         // for (_key, rc) in _rcs.iter_mut() {
         //     //pop the clipping context from the stack
         //     rc.restore();

--- a/pax-std/pax-std-primitives/src/image.rs
+++ b/pax-std/pax-std-primitives/src/image.rs
@@ -46,6 +46,12 @@ impl InstanceNode for ImageInstance {
     }
 
     fn handle_native_patches(&self, expanded_node: &ExpandedNode, rtc: &mut RuntimeContext) {
+        let val =
+            expanded_node.with_properties_unwrapped(|props: &mut Image| props.path.get().clone());
+        if rtc.image_map.contains_key(&val.string) {
+            return;
+        }
+
         let mut new_message: ImagePatch = Default::default();
         new_message.id_chain = expanded_node.id_chain.clone();
         let mut last_patches = self.last_patches.borrow_mut();
@@ -57,8 +63,6 @@ impl InstanceNode for ImageInstance {
         let last_patch = last_patches.get_mut(&new_message.id_chain).unwrap();
         let mut has_any_updates = false;
 
-        let val =
-            expanded_node.with_properties_unwrapped(|props: &mut Image| props.path.get().clone());
         let is_new_value = match &last_patch.path {
             Some(cached_value) => !val.string.eq(cached_value),
             None => true,

--- a/pax-std/pax-std-primitives/src/image.rs
+++ b/pax-std/pax-std-primitives/src/image.rs
@@ -93,8 +93,9 @@ impl InstanceNode for ImageInstance {
         let transformed_bounds =
             kurbo::Rect::new(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 
-        let _properties = (*expanded_node.properties).borrow();
-        if let Some(image) = rtc.image_map.get(&expanded_node.id_chain) {
+        let val =
+            expanded_node.with_properties_unwrapped(|props: &mut Image| props.path.get().clone());
+        if let Some(image) = rtc.image_map.get(&val.string) {
             rc.draw_image(&image, transformed_bounds);
         }
     }

--- a/pax-std/pax-std-primitives/src/image.rs
+++ b/pax-std/pax-std-primitives/src/image.rs
@@ -48,10 +48,6 @@ impl InstanceNode for ImageInstance {
     fn handle_native_patches(&self, expanded_node: &ExpandedNode, rtc: &mut RuntimeContext) {
         let val =
             expanded_node.with_properties_unwrapped(|props: &mut Image| props.path.get().clone());
-        if rtc.image_map.contains_key(&val.string) {
-            return;
-        }
-
         let mut new_message: ImagePatch = Default::default();
         new_message.id_chain = expanded_node.id_chain.clone();
         let mut last_patches = self.last_patches.borrow_mut();
@@ -82,7 +78,7 @@ impl InstanceNode for ImageInstance {
         &self,
         expanded_node: &ExpandedNode,
         rtc: &mut RuntimeContext,
-        rc: &mut Box<dyn RenderContext>,
+        rc: &mut dyn RenderContext,
     ) {
         let comp_props = &expanded_node.layout_properties.borrow();
         let comp_props = comp_props.as_ref().unwrap();
@@ -99,9 +95,8 @@ impl InstanceNode for ImageInstance {
 
         let val =
             expanded_node.with_properties_unwrapped(|props: &mut Image| props.path.get().clone());
-        if let Some(image) = rtc.image_map.get(&val.string) {
-            rc.draw_image(&image, transformed_bounds);
-        }
+        let layer_id = format!("{}", expanded_node.occlusion_id.borrow());
+        rc.draw_image(&layer_id, &val.string, transformed_bounds);
     }
 
     fn base(&self) -> &BaseInstance {

--- a/pax-std/pax-std-primitives/src/path.rs
+++ b/pax-std/pax-std-primitives/src/path.rs
@@ -48,8 +48,10 @@ impl InstanceNode for PathInstance {
         &self,
         expanded_node: &ExpandedNode,
         _rtc: &mut RuntimeContext,
-        rc: &mut Box<dyn RenderContext>,
+        rc: &mut dyn RenderContext,
     ) {
+        let layer_id = format!("{}", expanded_node.occlusion_id.borrow());
+
         expanded_node.with_properties_unwrapped(|properties: &mut Path| {
             let mut bez_path = BezPath::new();
 
@@ -77,8 +79,9 @@ impl InstanceNode for PathInstance {
             let duplicate_transformed_bez_path = transformed_bez_path.clone();
 
             let color = properties.fill.get().to_piet_color();
-            rc.fill(transformed_bez_path, &color.into());
+            rc.fill(&layer_id, transformed_bez_path, &color.into());
             rc.stroke(
+                &layer_id,
                 duplicate_transformed_bez_path,
                 &properties.stroke.get().color.get().to_piet_color().into(),
                 properties.stroke.get().width.get().into(),

--- a/pax-std/pax-std-primitives/src/text.rs
+++ b/pax-std/pax-std-primitives/src/text.rs
@@ -117,7 +117,7 @@ impl InstanceNode for TextInstance {
         &self,
         _expanded_node: &ExpandedNode,
         _context: &mut RuntimeContext,
-        _rc: &mut Box<dyn RenderContext>,
+        _rc: &mut dyn RenderContext,
     ) {
         //no-op -- only native rendering for Text (unless/until we support rasterizing text, which Piet should be able to handle!)
     }


### PR DESCRIPTION
This fixes image load problems introduced after the removal of RenderContext as a generic parameter. Images are now only loaded once (and never destroyed).

Some kind of chache invalidation will need to be performed at some point, some other day I think!