### PR TITLE
Fixed Text Flicker Bug

### DIFF
--- a/pax-chassis-web/interface/public/pax-chassis-web-interface.js
+++ b/pax-chassis-web/interface/public/pax-chassis-web-interface.js
@@ -376,7 +376,7 @@ var Pax = (() => {
     }
   };
 
-  // node_modules/snarkdown/dist/snarkdown.es.js
+  // ../node_modules/snarkdown/dist/snarkdown.es.js
   var e = { "": ["<em>", "</em>"], _: ["<strong>", "</strong>"], "*": ["<strong>", "</strong>"], "~": ["<s>", "</s>"], "\n": ["<br />"], " ": ["<br />"], "-": ["<hr />"] };
   function n(e2) {
     return e2.replace(RegExp("^" + (e2.match(/^(\t| )+/) || "")[0], "gm"), "");
@@ -912,6 +912,15 @@ var Pax = (() => {
       let leaf = this.textNodes[patch.id_chain];
       console.assert(leaf !== void 0);
       let textChild = leaf.firstChild;
+      if (patch.size_x != null) {
+        leaf.style.width = patch.size_x + "px";
+      }
+      if (patch.size_y != null) {
+        leaf.style.height = patch.size_y + "px";
+      }
+      if (patch.transform != null) {
+        leaf.style.transform = packAffineCoeffsIntoMatrix3DString(patch.transform);
+      }
       applyTextTyle(leaf, textChild, patch.style);
       if (patch.content != null) {
         textChild.innerHTML = t(patch.content);
@@ -951,15 +960,6 @@ var Pax = (() => {
             }
           });
         }
-      }
-      if (patch.size_x != null) {
-        leaf.style.width = patch.size_x + "px";
-      }
-      if (patch.size_y != null) {
-        leaf.style.height = patch.size_y + "px";
-      }
-      if (patch.transform != null) {
-        leaf.style.transform = packAffineCoeffsIntoMatrix3DString(patch.transform);
       }
     }
     textDelete(id_chain) {

--- a/pax-chassis-web/interface/src/classes/native-element-pool.ts
+++ b/pax-chassis-web/interface/src/classes/native-element-pool.ts
@@ -382,6 +382,19 @@ export class NativeElementPool {
 
         let textChild = leaf.firstChild;
 
+        // Handle size_x and size_y
+        if (patch.size_x != null) {
+            leaf.style.width = patch.size_x + "px";
+        }
+        if (patch.size_y != null) {
+            leaf.style.height = patch.size_y + "px";
+        }
+
+        // Handle transform
+        if (patch.transform != null) {
+            leaf.style.transform = packAffineCoeffsIntoMatrix3DString(patch.transform);
+        }
+
         applyTextTyle(leaf, textChild, patch.style);
 
         // Apply the content
@@ -427,19 +440,6 @@ export class NativeElementPool {
                     }
                 });
             }
-        }
-
-        // Handle size_x and size_y
-        if (patch.size_x != null) {
-            leaf.style.width = patch.size_x + "px";
-        }
-        if (patch.size_y != null) {
-            leaf.style.height = patch.size_y + "px";
-        }
-
-        // Handle transform
-        if (patch.transform != null) {
-            leaf.style.transform = packAffineCoeffsIntoMatrix3DString(patch.transform);
         }
     }
 

--- a/pax-core/src/repeat.rs
+++ b/pax-core/src/repeat.rs
@@ -79,6 +79,7 @@ impl InstanceNode for RepeatInstance {
                     &expanded_node.stack,
                     properties.source_expression_vec.as_mut(),
                 );
+
                 let vec = if let Some(ref source) = properties.source_expression_range {
                     Box::new(
                         source
@@ -93,6 +94,7 @@ impl InstanceNode for RepeatInstance {
                     //A valid Repeat must have a repeat source; presumably this has been gated by the parser / compiler
                     unreachable!();
                 };
+
                 let current_len = vec.len();
                 let exp_props = expanded_node.layout_properties.borrow();
                 let current_bounds = exp_props

--- a/pax-std/pax-std-primitives/src/button.rs
+++ b/pax-std/pax-std-primitives/src/button.rs
@@ -71,28 +71,34 @@ impl InstanceNode for ButtonInstance {
         expanded_node.with_properties_unwrapped(|properties: &mut Button| {
             let layout_properties = expanded_node.layout_properties.borrow();
             let computed_tab = &layout_properties.as_ref().unwrap().computed_tab;
-            let update_needed = patch_if_needed(
-                &mut old_state.content,
-                &mut patch.content,
-                properties.label.get().string.clone(),
-            ) || patch_if_needed(
-                &mut old_state.style,
-                &mut patch.style,
-                properties.style.get().into(),
-            ) || patch_if_needed(
-                &mut old_state.size_x,
-                &mut patch.size_x,
-                computed_tab.bounds.0,
-            ) || patch_if_needed(
-                &mut old_state.size_y,
-                &mut patch.size_y,
-                computed_tab.bounds.1,
-            ) || patch_if_needed(
-                &mut old_state.transform,
-                &mut patch.transform,
-                computed_tab.transform.as_coeffs().to_vec(),
-            );
-            if update_needed {
+            let updates = [
+                patch_if_needed(
+                    &mut old_state.content,
+                    &mut patch.content,
+                    properties.label.get().string.clone(),
+                ),
+                patch_if_needed(
+                    &mut old_state.style,
+                    &mut patch.style,
+                    properties.style.get().into(),
+                ),
+                patch_if_needed(
+                    &mut old_state.size_x,
+                    &mut patch.size_x,
+                    computed_tab.bounds.0,
+                ),
+                patch_if_needed(
+                    &mut old_state.size_y,
+                    &mut patch.size_y,
+                    computed_tab.bounds.1,
+                ),
+                patch_if_needed(
+                    &mut old_state.transform,
+                    &mut patch.transform,
+                    computed_tab.transform.as_coeffs().to_vec(),
+                ),
+            ];
+            if updates.into_iter().any(|v| v == true) {
                 context.enqueue_native_message(pax_message::NativeMessage::ButtonUpdate(patch));
             }
         });

--- a/pax-std/pax-std-primitives/src/text.rs
+++ b/pax-std/pax-std-primitives/src/text.rs
@@ -72,42 +72,44 @@ impl InstanceNode for TextInstance {
         expanded_node.with_properties_unwrapped(|properties: &mut Text| {
             let layout_properties = expanded_node.layout_properties.borrow();
             let computed_tab = &layout_properties.as_ref().unwrap().computed_tab;
-            let update_needed =
 
-            // Content
+            let updates = [
+                // Content
                 patch_if_needed(
-                &mut old_state.content,
-                &mut patch.content,
-                properties.text.get().string.clone(),
-            )
+                    &mut old_state.content,
+                    &mut patch.content,
+                    properties.text.get().string.clone(),
+                ),
+                // Styles
+                patch_if_needed(
+                    &mut old_state.style,
+                    &mut patch.style,
+                    properties.style.get().into(),
+                ),
+                patch_if_needed(
+                    &mut old_state.style_link,
+                    &mut patch.style_link,
+                    properties.style_link.get().into(),
+                ),
+                // Transform and bounds
+                patch_if_needed(
+                    &mut old_state.size_x,
+                    &mut patch.size_x,
+                    computed_tab.bounds.0,
+                ),
+                patch_if_needed(
+                    &mut old_state.size_y,
+                    &mut patch.size_y,
+                    computed_tab.bounds.1,
+                ),
+                patch_if_needed(
+                    &mut old_state.transform,
+                    &mut patch.transform,
+                    computed_tab.transform.as_coeffs().to_vec(),
+                ),
+            ];
 
-            // Styles
-              || patch_if_needed(
-                &mut old_state.style,
-                &mut patch.style,
-                properties.style.get().into(),
-            ) || patch_if_needed(
-                &mut old_state.style_link,
-                &mut patch.style_link,
-                properties.style_link.get().into(),
-            )
-
-            // Transform and bounds 
-              || patch_if_needed(
-                &mut old_state.size_x,
-                &mut patch.size_x,
-                computed_tab.bounds.0,
-            ) || patch_if_needed(
-                &mut old_state.size_y,
-                &mut patch.size_y,
-                computed_tab.bounds.1,
-            ) || patch_if_needed(
-                &mut old_state.transform,
-                &mut patch.transform,
-                computed_tab.transform.as_coeffs().to_vec(),
-            );
-
-            if update_needed {
+            if updates.into_iter().any(|v| v == true) {
                 context.enqueue_native_message(pax_message::NativeMessage::TextUpdate(patch));
             }
         });

--- a/pax-std/pax-std-primitives/src/textbox.rs
+++ b/pax-std/pax-std-primitives/src/textbox.rs
@@ -62,24 +62,29 @@ impl InstanceNode for TextboxInstance {
         expanded_node.with_properties_unwrapped(|properties: &mut Textbox| {
             let layout_properties = expanded_node.layout_properties.borrow();
             let computed_tab = &layout_properties.as_ref().unwrap().computed_tab;
-            let update_needed = patch_if_needed(
-                &mut old_state.text,
-                &mut patch.text,
-                properties.text.get().string.clone(),
-            ) || patch_if_needed(
-                &mut old_state.size_x,
-                &mut patch.size_x,
-                computed_tab.bounds.0,
-            ) || patch_if_needed(
-                &mut old_state.size_y,
-                &mut patch.size_y,
-                computed_tab.bounds.1,
-            ) || patch_if_needed(
-                &mut old_state.transform,
-                &mut patch.transform,
-                computed_tab.transform.as_coeffs().to_vec(),
-            );
-            if update_needed {
+            let updates = [
+                patch_if_needed(
+                    &mut old_state.text,
+                    &mut patch.text,
+                    properties.text.get().string.clone(),
+                ),
+                patch_if_needed(
+                    &mut old_state.size_x,
+                    &mut patch.size_x,
+                    computed_tab.bounds.0,
+                ),
+                patch_if_needed(
+                    &mut old_state.size_y,
+                    &mut patch.size_y,
+                    computed_tab.bounds.1,
+                ),
+                patch_if_needed(
+                    &mut old_state.transform,
+                    &mut patch.transform,
+                    computed_tab.transform.as_coeffs().to_vec(),
+                ),
+            ];
+            if updates.into_iter().any(|v| v == true) {
                 context.enqueue_native_message(pax_message::NativeMessage::TextboxUpdate(patch));
             }
         });

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -67,6 +67,7 @@ pub mod primitives {
     #[derive(Pax)]
     #[custom(Imports)]
     #[primitive("pax_std_primitives::text::TextInstance")]
+    #[cfg_attr(debug_assertions, derive(Debug))]
     pub struct Text {
         pub text: Property<StringBox>,
         pub style: Property<TextStyle>,


### PR DESCRIPTION
Text flickering when being destroyed and recreated fixed! Text was being updated one property at a time, one on each tick because of the way patches where being computed (|| short circuits evaluation).

