### PR TITLE
Pre Compute handle

### DIFF
--- a/pax-compiler/templates/cartridge_generation/cartridge-component-factory.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge-component-factory.tera
@@ -15,7 +15,7 @@ pub fn instantiate_main_component() -> Rc<ComponentInstance> {
                         {% if handler.source_map_start_marker %}
                             {{handler.source_map_start_marker}}
                         {% endif %}
-                        {%- if entry.0.content in ['pre_render','mount'] -%}
+                        {%- if entry.0.content in ['pre_compute', 'pre_render','mount'] -%}
                             |properties, ctx|{
                                 let properties = &mut *properties.as_ref().borrow_mut();
                                 if let Some(mut synthesized_self) = properties.downcast_mut::<{{fully_qualified_properties_type}}>() {
@@ -88,7 +88,7 @@ pub fn instantiate_{{ snake_case_type_id }}(mut args: InstantiationArgs) -> Rc<C
         {% if handler.source_map_start_marker %}
             {{handler.source_map_start_marker}}
         {% endif %}
-         {%- if entry.0.content in ['pre_render','mount'] -%}
+         {%- if entry.0.content in ['pre_compute', 'pre_render','mount'] -%}
              |properties, ctx|{
                  let properties = &mut *properties.as_ref().borrow_mut();
 

--- a/pax-compiler/templates/cartridge_generation/cartridge-render-node-literal.tera
+++ b/pax-compiler/templates/cartridge_generation/cartridge-render-node-literal.tera
@@ -44,7 +44,7 @@ instantiate_{{ snake_case_type_id }}(
                 {% if entry.1.source_map_start_marker %}
                     {{entry.1.source_map_start_marker}}
                 {% endif %}
-                {%- if entry.0.content in ['pre_render','mount'] -%}
+                {%- if entry.0.content in ['pre_compute', 'pre_render','mount'] -%}
                     |properties, ctx|{
 
                        let properties = &mut *properties.as_ref().borrow_mut();

--- a/pax-core/src/engine.rs
+++ b/pax-core/src/engine.rs
@@ -100,6 +100,7 @@ pub struct HandlerRegistry {
     pub context_menu_handlers: Vec<fn(Rc<RefCell<dyn Any>>, &NodeContext, ArgsContextMenu)>,
     pub wheel_handlers: Vec<fn(Rc<RefCell<dyn Any>>, &NodeContext, ArgsWheel)>,
     pub pre_render_handlers: Vec<fn(Rc<RefCell<dyn Any>>, &NodeContext)>,
+    pub pre_compute_handlers: Vec<fn(Rc<RefCell<dyn Any>>, &NodeContext)>,
     pub mount_handlers: Vec<fn(Rc<RefCell<dyn Any>>, &NodeContext)>,
 }
 
@@ -128,6 +129,7 @@ impl Default for HandlerRegistry {
             checkbox_change_handlers: Vec::new(),
             button_click_handlers: Vec::new(),
             textbox_change_handlers: Vec::new(),
+            pre_compute_handlers: Vec::new(),
         }
     }
 }
@@ -357,8 +359,6 @@ impl PaxEngine {
         // completely remove once reactive properties dirty-dag is a thing.
         //
         self.root_node.recurse_update(&mut self.runtime_context);
-        self.root_node
-            .recurse_update_native_patches(&mut self.runtime_context);
 
         // 2. LAYER-IDS, z-index list creation Will always be recomputed each
         // frame. Nothing intensive is to be done here.

--- a/pax-language-server/src/completion.rs
+++ b/pax-language-server/src/completion.rs
@@ -297,6 +297,7 @@ lazy_static! {
             ("double_click", "Set Double Click event handler"),
             ("context_menu", "Set Context Menu event handler"),
             ("wheel", "Set Wheel event handler"),
+            ("pre_compute", "Set Pre Compute  event handler"),
             ("pre_render", "Set Will Render event handler"),
             ("mount", "Set Did Mount event handler"),
         ];

--- a/pax-manifest/src/lib.rs
+++ b/pax-manifest/src/lib.rs
@@ -8,6 +8,7 @@ use serde_json;
 
 /// Definition container for an entire Pax cartridge
 #[derive(Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct PaxManifest {
     pub components: HashMap<String, ComponentDefinition>,
     pub main_component_type_id: String,
@@ -36,8 +37,8 @@ impl Ord for ExpressionSpec {
     }
 }
 
-#[cfg_attr(debug_assertions, derive(Debug))]
 #[derive(Serialize, Deserialize, Clone)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct ExpressionSpec {
     /// Unique id for vtable entry — used for binding a node definition property to vtable
     pub id: usize,
@@ -120,7 +121,8 @@ impl ExpressionSpecInvocation {
 
 /// Container for an entire component definition — includes template, settings,
 /// event bindings, property definitions, and compiler + reflection metadata
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct ComponentDefinition {
     pub type_id: String,
     pub type_id_escaped: String,
@@ -285,7 +287,8 @@ impl PropertyDefinition {
 }
 
 /// Describes metadata surrounding a property's type, gathered from a combination of static & dynamic analysis
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct TypeDefinition {
     /// Program-unique ID for this type
     pub type_id: String,

--- a/pax-std/src/stacker.rs
+++ b/pax-std/src/stacker.rs
@@ -23,7 +23,7 @@ use pax_runtime_api::{NodeContext, PropertyLiteral};
     }
 
     @handlers {
-        pre_render: handle_pre_render
+        pre_compute: handle_pre_compute
     }
 
 )]
@@ -51,7 +51,7 @@ impl Default for Stacker {
 }
 
 impl Stacker {
-    pub fn handle_pre_render(&mut self, ctx: &NodeContext) {
+    pub fn handle_pre_compute(&mut self, ctx: &NodeContext) {
         let cells = self.cells.get().get_as_float();
         let bounds = ctx.bounds_self;
 


### PR DESCRIPTION
This introduces a new pre-compute handle (runs before property updates) and moves the pre_render handle to after property updates for a given node (but before it's children, for now).