### PR TITLE
Add tests to pax-manifest parsing

### DIFF
--- a/pax-manifest/src/utils.rs
+++ b/pax-manifest/src/utils.rs
@@ -10,6 +10,12 @@ use pest_derive::Parser;
 pub struct PaxParser;
 
 pub fn parse_value(raw_value: &str) -> Result<ValueDefinition> {
+    if raw_value.is_empty() {
+        return Ok(ValueDefinition::LiteralValue(Token::new_only_raw(
+            "".to_owned(),
+            TokenType::LiteralValue,
+        )));
+    }
     let mut values = PaxParser::parse(Rule::any_template_value, raw_value)?;
     if values.as_str() != raw_value {
         return Err(anyhow!("no rule matched entire raw value"));

--- a/pax-manifest/src/utils.rs
+++ b/pax-manifest/src/utils.rs
@@ -10,12 +10,6 @@ use pest_derive::Parser;
 pub struct PaxParser;
 
 pub fn parse_value(raw_value: &str) -> Result<ValueDefinition> {
-    if raw_value.is_empty() {
-        return Ok(ValueDefinition::LiteralValue(Token::new_only_raw(
-            "".to_owned(),
-            TokenType::LiteralValue,
-        )));
-    }
     let mut values = PaxParser::parse(Rule::any_template_value, raw_value)?;
     if values.as_str() != raw_value {
         return Err(anyhow!("no rule matched entire raw value"));

--- a/pax-manifest/tests/tests.rs
+++ b/pax-manifest/tests/tests.rs
@@ -1,0 +1,47 @@
+#[cfg(test)]
+#[cfg(feature = "parsing")]
+mod tests {
+
+    use pax_manifest::{utils, ValueDefinition};
+
+    #[test]
+    fn test_parse_embty() {
+        assert!(matches!(utils::parse_value(""), Ok(_)));
+    }
+
+    #[test]
+    fn test_parse_identifier() {
+        let res = utils::parse_value("identifier");
+        if let Ok(ValueDefinition::Identifier(token, _)) = res {
+            assert_eq!(&token.raw_value, "identifier");
+        } else {
+            panic!("unexpected result: {:?}", res);
+        }
+    }
+
+    #[test]
+    fn test_parse_literal_number() {
+        let res = utils::parse_value("5");
+        if let Ok(ValueDefinition::LiteralValue(token)) = res {
+            assert_eq!(&token.raw_value, "5");
+        } else {
+            panic!("unexpected result: {:?}", res);
+        }
+    }
+
+    #[test]
+    fn test_parse_expression() {
+        let res = utils::parse_value("{5 + 3}");
+        if let Ok(ValueDefinition::Expression(token, _)) = res {
+            assert_eq!(&token.raw_value, "{5 + 3}");
+        } else {
+            panic!("unexpected result: {:?}", res);
+        }
+    }
+
+    #[test]
+    fn test_parse_with_extra() {
+        let res = utils::parse_value("{5 + 3}this_shouldn't succeed");
+        assert!(matches!(res, Err(_)));
+    }
+}

--- a/pax-manifest/tests/tests.rs
+++ b/pax-manifest/tests/tests.rs
@@ -5,8 +5,8 @@ mod tests {
     use pax_manifest::{utils, ValueDefinition};
 
     #[test]
-    fn test_parse_embty() {
-        assert!(matches!(utils::parse_value(""), Ok(_)));
+    fn test_parse_empty() {
+        assert!(matches!(utils::parse_value(""), Err(_)));
     }
 
     #[test]


### PR DESCRIPTION
This adds some simple tests for the pax-manifest utils function parse_value.