### PR TITLE
Fully qualify imports in #[pax] macro

### DIFF
--- a/examples/src/camera/src/lib.rs
+++ b/examples/src/camera/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 use pax_lang::api::{ArgsClick, EasingCurve, NodeContext, Property};
 use pax_lang::Pax;
-use pax_std::primitives::{Rectangle, Group, Frame, Text, Ellipse};
+use pax_std::primitives::{Ellipse, Frame, Group, Rectangle, Text};
 
 #[pax]
 #[main]
@@ -15,7 +15,6 @@ pub struct Camera {
 }
 
 #[pax]
-#[custom(Imports)]
 pub struct TypeExample {
     pub foo: Property<usize>,
 }
@@ -28,12 +27,16 @@ impl Camera {
     }
 
     pub fn handle_click(&mut self, _: NodeContext, args: ArgsClick) {
-        let delta_pan = (args.mouse.x - self.pan_x.get(), args.mouse.y - self.pan_y.get());
-        self.pan_x.ease_to(self.pan_x.get() + delta_pan.0, 200, EasingCurve::Linear);
-        self.pan_y.ease_to(self.pan_y.get() + delta_pan.1, 200, EasingCurve::Linear);
+        let delta_pan = (
+            args.mouse.x - self.pan_x.get(),
+            args.mouse.y - self.pan_y.get(),
+        );
+        self.pan_x
+            .ease_to(self.pan_x.get() + delta_pan.0, 200, EasingCurve::Linear);
+        self.pan_y
+            .ease_to(self.pan_y.get() + delta_pan.1, 200, EasingCurve::Linear);
 
         self.zoom.ease_to(0.5, 100, EasingCurve::OutQuad);
         self.zoom.ease_to_later(2.0, 100, EasingCurve::InQuad)
     }
-
 }

--- a/examples/src/pax-intro/src/lib.rs
+++ b/examples/src/pax-intro/src/lib.rs
@@ -20,7 +20,6 @@ pub struct DynamicObject {
 }
 
 #[pax]
-#[custom(Imports)]
 pub struct Rect {
     pub x: Size,
     pub y: Size,

--- a/examples/src/three-repeats/src/lib.rs
+++ b/examples/src/three-repeats/src/lib.rs
@@ -1,12 +1,12 @@
 #![allow(unused_imports)]
 
-use pax_lang::*;
 use pax_lang::api::*;
-use pax_std::primitives::*;
-use pax_std::types::*;
-use pax_std::types::text::*;
-use pax_std::components::*;
+use pax_lang::*;
 use pax_std::components::Stacker;
+use pax_std::components::*;
+use pax_std::primitives::*;
+use pax_std::types::text::*;
+use pax_std::types::*;
 
 #[pax]
 #[main]
@@ -20,28 +20,17 @@ impl Default for ThreeRepeats {
     fn default() -> Self {
         Self {
             some_data: Box::new(PropertyLiteral::new(vec![
-                CustomStruct{
-                    x: 250
-                },
-                CustomStruct{
-                    x: 300
-                },
-                CustomStruct{
-                    x: 450
-                },
-                CustomStruct{
-                    x: 550
-                },
-                CustomStruct{
-                    x: 850
-                }
-            ]))
+                CustomStruct { x: 250 },
+                CustomStruct { x: 300 },
+                CustomStruct { x: 450 },
+                CustomStruct { x: 550 },
+                CustomStruct { x: 850 },
+            ])),
         }
     }
 }
 
 #[pax]
-#[custom(Imports)]
 pub struct CustomStruct {
     pub x: isize,
 }

--- a/pax-macro/src/templating.rs
+++ b/pax-macro/src/templating.rs
@@ -42,6 +42,5 @@ pub struct TemplateArgsDerivePax {
     /// Shared properties
     pub static_property_definitions: Vec<StaticPropertyDefinition>,
     pub pascal_identifier: String,
-    pub include_imports: bool,
     pub is_custom_interpolatable: bool,
 }

--- a/pax-macro/templates/derive_pax.stpl
+++ b/pax-macro/templates/derive_pax.stpl
@@ -1,10 +1,3 @@
-<% if include_imports { %>
-    #[cfg(feature = "parser")]
-    use pax_compiler::parsing::Reflectable;
-    #[cfg(feature = "parser")]
-    use serde_json;
-<% } %>
-
 <% if args_full_component.as_ref().is_some() && args_full_component.as_ref().unwrap().is_main_component { %>
     // For the main (application-root) component only, a `main` is generated for the `parser` bin target.
     // This method bootstraps the parsing process, parsing not only the main/application-root component
@@ -15,14 +8,14 @@
 
         let mut ctx = pax_compiler::parsing::ParsingContext::default();
 
-        let (mut ctx, _) = <%= pascal_identifier %>::parse_to_manifest(ctx);
+        let (mut ctx, _) = <<%= pascal_identifier %> as pax_compiler::parsing::Reflectable>::parse_to_manifest(ctx);
 
         //Special-case pax_runtime_api built-ins, ensure they're imported at least once because it's a built-in but must be surfaced through
         //the userland project in order to ensure deduping
-        ctx.import_paths.insert(pax_lang::api::Size::get_import_path());
-        ctx.import_paths.insert(pax_lang::api::Numeric::get_import_path());
-        ctx.import_paths.insert(pax_lang::api::Rotation::get_import_path());
-        ctx.import_paths.insert(pax_lang::api::Transform2D::get_import_path());
+        ctx.import_paths.insert(<pax_lang::api::Size as pax_compiler::parsing::Reflectable>::get_import_path());
+        ctx.import_paths.insert(<pax_lang::api::Numeric as pax_compiler::parsing::Reflectable>::get_import_path());
+        ctx.import_paths.insert(<pax_lang::api::Rotation as pax_compiler::parsing::Reflectable>::get_import_path());
+        ctx.import_paths.insert(<pax_lang::api::Transform2D as pax_compiler::parsing::Reflectable>::get_import_path());
 
         let manifest = pax_manifest::PaxManifest {
             components: ctx.component_definitions,

--- a/pax-std/src/lib.rs
+++ b/pax-std/src/lib.rs
@@ -21,12 +21,10 @@ pub mod primitives {
     pub struct Frame {}
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::group::GroupInstance")]
     pub struct Group {}
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::scroller::ScrollerInstance")]
     pub struct Scroller {
         pub size_inner_pane_x: Property<Size>,
@@ -36,7 +34,6 @@ pub mod primitives {
     }
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::rectangle::RectangleInstance")]
     #[cfg_attr(debug_assertions, derive(Debug))]
     pub struct Rectangle {
@@ -46,7 +43,6 @@ pub mod primitives {
     }
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::ellipse::EllipseInstance")]
     #[cfg_attr(debug_assertions, derive(Debug))]
     pub struct Ellipse {
@@ -55,7 +51,6 @@ pub mod primitives {
     }
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::path::PathInstance")]
     #[cfg_attr(debug_assertions, derive(Debug))]
     pub struct Path {
@@ -65,7 +60,6 @@ pub mod primitives {
     }
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::text::TextInstance")]
     #[cfg_attr(debug_assertions, derive(Debug))]
     pub struct Text {
@@ -75,21 +69,18 @@ pub mod primitives {
     }
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::checkbox::CheckboxInstance")]
     pub struct Checkbox {
         pub checked: Property<bool>,
     }
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::textbox::TextboxInstance")]
     pub struct Textbox {
         pub text: Property<StringBox>,
     }
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::button::ButtonInstance")]
     pub struct Button {
         pub label: Property<StringBox>,
@@ -97,7 +88,6 @@ pub mod primitives {
     }
 
     #[pax]
-    #[custom(Imports)]
     #[primitive("pax_std_primitives::image::ImageInstance")]
     pub struct Image {
         pub path: Property<StringBox>,

--- a/pax-std/src/types/mod.rs
+++ b/pax-std/src/types/mod.rs
@@ -28,7 +28,6 @@ impl Default for Stroke {
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[pax]
-#[custom(Imports)]
 pub struct StackerCell {
     pub x_px: f64,
     pub y_px: f64,
@@ -37,7 +36,6 @@ pub struct StackerCell {
 }
 
 #[pax]
-#[custom(Imports)]
 pub enum StackerDirection {
     Vertical,
     #[default]
@@ -45,7 +43,6 @@ pub enum StackerDirection {
 }
 
 #[pax]
-#[custom(Imports)]
 pub enum SidebarDirection {
     Left,
     #[default]
@@ -54,7 +51,7 @@ pub enum SidebarDirection {
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[pax]
-#[custom(Default, Imports)]
+#[custom(Default)]
 pub enum Fill {
     Solid(Color),
     LinearGradient(LinearGradient),
@@ -63,7 +60,6 @@ pub enum Fill {
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[pax]
-#[custom(Imports)]
 pub struct LinearGradient {
     pub start: (Size, Size),
     pub end: (Size, Size),
@@ -72,7 +68,6 @@ pub struct LinearGradient {
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[pax]
-#[custom(Imports)]
 pub struct RadialGradient {
     pub end: (Size, Size),
     pub start: (Size, Size),
@@ -82,7 +77,6 @@ pub struct RadialGradient {
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[pax]
-#[custom(Imports)]
 pub struct GradientStop {
     pub position: Size,
     pub color: Color,
@@ -149,7 +143,7 @@ impl Fill {
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[pax]
-#[custom(Default, Imports)]
+#[custom(Default)]
 pub struct Color {
     pub color_variant: ColorVariant,
 }
@@ -253,7 +247,7 @@ impl PartialEq<ColorVariantMessage> for Color {
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[pax]
-#[custom(Default, Imports)]
+#[custom(Default)]
 pub enum ColorVariant {
     Hlca([f64; 4]),
     Hlc([f64; 3]),
@@ -268,7 +262,6 @@ impl Default for ColorVariant {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum PathSegment {
     #[default]
@@ -284,7 +277,6 @@ impl PathSegment {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct LineSegmentData {
     pub start: Point,
@@ -298,7 +290,6 @@ impl LineSegmentData {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct CurveSegmentData {
     pub start: Point,
@@ -307,7 +298,6 @@ pub struct CurveSegmentData {
 }
 
 #[pax]
-#[custom(Imports)]
 #[derive(Copy)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct Point {
@@ -353,7 +343,6 @@ impl Path {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct RectangleCornerRadii {
     pub top_left: Property<f64>,

--- a/pax-std/src/types/text.rs
+++ b/pax-std/src/types/text.rs
@@ -113,7 +113,7 @@ impl PartialEq<TextStyleMessage> for TextStyle {
 
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[pax]
-#[custom(Default, Imports)]
+#[custom(Default)]
 pub enum Font {
     System(SystemFont),
     Web(WebFont),
@@ -127,7 +127,7 @@ impl Default for Font {
 }
 
 #[pax]
-#[custom(Imports, Default)]
+#[custom(Default)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct SystemFont {
     pub family: StringBox,
@@ -146,7 +146,6 @@ impl Default for SystemFont {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct WebFont {
     pub family: StringBox,
@@ -156,7 +155,6 @@ pub struct WebFont {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct LocalFont {
     pub family: StringBox,
@@ -166,7 +164,6 @@ pub struct LocalFont {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum FontStyle {
     #[default]
@@ -176,7 +173,6 @@ pub enum FontStyle {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum FontWeight {
     Thin,
@@ -192,7 +188,6 @@ pub enum FontWeight {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum TextAlignHorizontal {
     #[default]
@@ -202,7 +197,6 @@ pub enum TextAlignHorizontal {
 }
 
 #[pax]
-#[custom(Imports)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum TextAlignVertical {
     #[default]


### PR DESCRIPTION
This removes the need to do specify custom(Imports) for the pax macro.
