### PR TITLE
Introduce "log" crate

### DIFF
--- a/pax-chassis-common/Cargo.toml
+++ b/pax-chassis-common/Cargo.toml
@@ -12,6 +12,7 @@ include = ["src/**/*","pax-swift-common/**/*"]
 [lib]
 
 [dependencies]
+env_logger = "0.11.1"
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
 pax-runtime = { path = "../pax-runtime", version="0.12.0" }

--- a/pax-chassis-common/pax-swift-cartridge/PaxCartridge.xcframework/ios-arm64/PaxCartridge.framework/Headers/PaxCartridge.h
+++ b/pax-chassis-common/pax-swift-cartridge/PaxCartridge.xcframework/ios-arm64/PaxCartridge.framework/Headers/PaxCartridge.h
@@ -20,7 +20,7 @@ typedef struct InterruptBuffer {
 
 typedef struct PaxEngineContainer PaxEngineContainer;
 
-struct PaxEngineContainer *pax_init(void (*logger)(const char*));
+struct PaxEngineContainer *pax_init();
 
 void pax_dealloc_engine(struct PaxEngineContainer * container);
 

--- a/pax-chassis-common/pax-swift-cartridge/PaxCartridge.xcframework/ios-arm64_x86_64-simulator/PaxCartridge.framework/Headers/PaxCartridge.h
+++ b/pax-chassis-common/pax-swift-cartridge/PaxCartridge.xcframework/ios-arm64_x86_64-simulator/PaxCartridge.framework/Headers/PaxCartridge.h
@@ -20,7 +20,7 @@ typedef struct InterruptBuffer {
 
 typedef struct PaxEngineContainer PaxEngineContainer;
 
-struct PaxEngineContainer *pax_init(void (*logger)(const char*));
+struct PaxEngineContainer *pax_init();
 
 void pax_dealloc_engine(struct PaxEngineContainer * container);
 

--- a/pax-chassis-common/pax-swift-cartridge/PaxCartridge.xcframework/macos-arm64_x86_64/PaxCartridge.framework/Headers/PaxCartridge.h
+++ b/pax-chassis-common/pax-swift-cartridge/PaxCartridge.xcframework/macos-arm64_x86_64/PaxCartridge.framework/Headers/PaxCartridge.h
@@ -20,7 +20,7 @@ typedef struct InterruptBuffer {
 
 typedef struct PaxEngineContainer PaxEngineContainer;
 
-struct PaxEngineContainer *pax_init(void (*logger)(const char*));
+struct PaxEngineContainer *pax_init();
 
 void pax_dealloc_engine(struct PaxEngineContainer * container);
 

--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -5,7 +5,6 @@ extern crate core;
 use std::ffi::c_void;
 
 use std::mem::{transmute, ManuallyDrop};
-use std::os::raw::c_char;
 
 use core_graphics::context::CGContext;
 use pax_runtime::math::Point2;
@@ -35,7 +34,8 @@ pub struct PaxEngineContainer {
 
 /// Allocate an instance of the Pax engine, with a specified root/main component from the loaded `pax_cartridge`.
 #[no_mangle] //Exposed to Swift via PaxCartridge.h
-pub extern "C" fn pax_init(logger: extern "C" fn(*const c_char)) -> *mut PaxEngineContainer {
+pub extern "C" fn pax_init() -> *mut PaxEngineContainer {
+    env_logger::init();
     //Initialize a ManuallyDrop-contained PaxEngine, so that a pointer to that
     //engine can be passed back to Swift via the C (FFI) bridge
     //This could presumably be cleaned up -- see `pax_dealloc_engine`
@@ -47,7 +47,6 @@ pub extern "C" fn pax_init(logger: extern "C" fn(*const c_char)) -> *mut PaxEngi
     let engine: ManuallyDrop<Box<PaxEngine>> = ManuallyDrop::new(Box::new(PaxEngine::new(
         main_component_instance,
         expression_table,
-        pax_runtime::api::PlatformSpecificLogger::MacOS(logger),
         (1.0, 1.0),
     )));
 

--- a/pax-chassis-macos/interface/pax-app-macos/pax-app-macos/PaxViewMacos.swift
+++ b/pax-chassis-macos/interface/pax-app-macos/pax-app-macos/PaxViewMacos.swift
@@ -154,18 +154,7 @@ struct PaxViewMacos: View {
             var cgContext = context.cgContext
 
             if PaxEngineContainer.paxEngineContainer == nil {
-                let swiftLoggerCallback : @convention(c) (UnsafePointer<CChar>?) -> () = {
-                    (msg) -> () in
-                    let outputString = String(cString: msg!)
-                    print(outputString)
-                }
-
-                //For manual debugger attachment:
-//                do {
-//                    sleep(15)
-//                }
-
-                PaxEngineContainer.paxEngineContainer = pax_init(swiftLoggerCallback)
+                PaxEngineContainer.paxEngineContainer = pax_init()
             } else {
 
                 let nativeMessageQueue = pax_tick(PaxEngineContainer.paxEngineContainer!, &cgContext, CFloat(dirtyRect.width), CFloat(dirtyRect.height))

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -22,6 +22,8 @@ pax-cartridge = {path="../pax-cartridge", version="0.12.0"}
 pax-message = {path = "../pax-message", version="0.12.0"}
 wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 serde_json = "1.0.95"
+console_log = "1.0.0"
+log = "0.4.20"
 console_error_panic_hook = { version = "0.1.6", optional = true }
 js-sys = "0.3.63"
 

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -58,8 +58,14 @@ impl PaxChassisWeb {
     pub fn new() -> Self {
         #[cfg(feature = "console_error_panic_hook")]
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+
+        #[cfg(debug_assertions)]
         console_log::init_with_level(Level::Debug)
             .expect("console_log::init_with_level initialized correctly");
+        #[cfg(not(debug_assertions))]
+        console_log::init_with_level(Level::Error)
+            .expect("console_log::init_with_level initialized correctly");
+
         let window = window().unwrap();
         let width = window.inner_width().unwrap().as_f64().unwrap();
         let height = window.inner_height().unwrap().as_f64().unwrap();

--- a/pax-engine/Cargo.toml
+++ b/pax-engine/Cargo.toml
@@ -15,6 +15,7 @@ pax-macro = {path="../pax-macro", version="0.12.0"}
 pax-message = {path="../pax-message", version="0.12.0"}
 pax-runtime = {path="../pax-runtime", version="0.12.0"}
 pax-compiler = {path="../pax-compiler", optional=true, version="0.12.0"}
+log = "0.4.20"
 
 [features]
 parser = ["dep:pax-compiler"]

--- a/pax-engine/src/lib.rs
+++ b/pax-engine/src/lib.rs
@@ -1,12 +1,12 @@
 pub extern crate pax_macro;
 pub use pax_macro::*;
 
+pub use log;
 pub use pax_runtime::api;
 pub use pax_runtime::engine::node_interface::*;
 pub use pax_runtime::math;
 pub use pax_runtime::rendering;
 
-pub use pax_runtime::api::log;
 pub use pax_runtime::api::serde;
 pub use pax_runtime::api::Property;
 

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -253,12 +253,9 @@ impl PaxEngine {
     pub fn new(
         main_component_instance: Rc<ComponentInstance>,
         expression_table: ExpressionTable,
-        logger: crate::api::PlatformSpecificLogger,
         viewport_size: (f64, f64),
     ) -> Self {
         use crate::math::Transform2;
-
-        crate::api::register_logger(logger);
 
         let globals = Globals {
             frames_elapsed: 0,
@@ -282,14 +279,10 @@ impl PaxEngine {
     pub fn new_with_designtime(
         main_component_instance: Rc<ComponentInstance>,
         expression_table: ExpressionTable,
-        logger: crate::api::PlatformSpecificLogger,
         viewport_size: (f64, f64),
         designtime: Rc<RefCell<DesigntimeManager>>,
     ) -> Self {
         use crate::math::Transform2;
-
-        crate::api::register_logger(logger);
-
         let globals = Globals {
             frames_elapsed: 0,
             viewport: TransformAndBounds {


### PR DESCRIPTION
This introduces the [log](https://docs.rs/log/latest/log/) crate into pax.

Working on both web and macos. (For macos, need to specify RUST_LOG env variable when running, see docs for [env_logger](https://docs.rs/env_logger/latest/env_logger/)). For web currently hardcoded to log::Level::Debug for debug builds and log::Level::Error on release builds.

log crate is re-exported through pax-engine:

```rust
pax_engine::log::info!("some info");
pax_engine::log::warn!("this just failed: {}", self.something);
```


