### PR TITLE
Add textbox change event

### DIFF
--- a/pax-chassis-web/interface/src/classes/native-element-pool.ts
+++ b/pax-chassis-web/interface/src/classes/native-element-pool.ts
@@ -189,6 +189,18 @@ export class NativeElementPool {
         textbox.type = "text";
         textbox.addEventListener("input", (_event) => {
             let message = {
+                "FormTextboxInput": {
+                    "id_chain": patch.idChain!,
+                    "text": textbox.value,
+                }
+            }
+            this.chassis!.interrupt(JSON.stringify(message), undefined);
+            // @ts-ignore
+            textbox.value = textbox.fixed_text_value;
+        });
+
+        textbox.addEventListener("change", (_event) => {
+            let message = {
                 "FormTextboxChange": {
                     "id_chain": patch.idChain!,
                     "text": textbox.value,

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -4,6 +4,7 @@ use js_sys::Uint8Array;
 use pax_runtime::api::ArgsButtonClick;
 use pax_runtime::api::ArgsCheckboxChange;
 use pax_runtime::api::ArgsTextboxChange;
+use pax_runtime::api::ArgsTextboxInput;
 use pax_runtime::api::RenderContext;
 use pax_runtime::ExpressionTable;
 use std::cell::RefCell;
@@ -187,6 +188,16 @@ impl PaxChassisWeb {
                     .get_expanded_node(args.id_chain[0])
                     .expect("button node exists in engine");
                 node.dispatch_button_click(ArgsButtonClick {}, globals, &engine.runtime_context);
+            }
+            NativeInterrupt::FormTextboxInput(args) => {
+                let node = engine
+                    .get_expanded_node(args.id_chain[0])
+                    .expect("textbox node exists in engine");
+                node.dispatch_textbox_input(
+                    ArgsTextboxInput { text: args.text },
+                    globals,
+                    &engine.runtime_context,
+                );
             }
             NativeInterrupt::FormTextboxChange(args) => {
                 let node = engine

--- a/pax-manifest/src/cartridge_generation/mod.rs
+++ b/pax-manifest/src/cartridge_generation/mod.rs
@@ -51,44 +51,30 @@ impl PaxManifest {
 
     pub fn event_to_args_map(&self) -> HashMap<String, Option<String>> {
         let mut map = HashMap::new();
-        map.insert("scroll".to_string(), Some("ArgsScroll".to_string()));
-        map.insert("clap".to_string(), Some("ArgsClap".to_string()));
-        map.insert(
-            "touch_start".to_string(),
-            Some("ArgsTouchStart".to_string()),
-        );
-        map.insert("touch_move".to_string(), Some("ArgsTouchMove".to_string()));
-        map.insert("touch_end".to_string(), Some("ArgsTouchEnd".to_string()));
-        map.insert("key_down".to_string(), Some("ArgsKeyDown".to_string()));
-        map.insert("key_up".to_string(), Some("ArgsKeyUp".to_string()));
-        map.insert("key_press".to_string(), Some("ArgsKeyPress".to_string()));
-        map.insert(
-            "checkbox_change".to_string(),
-            Some("ArgsCheckboxChange".to_string()),
-        );
-        map.insert(
-            "button_click".to_string(),
-            Some("ArgsButtonClick".to_string()),
-        );
-        map.insert(
-            "textbox_change".to_string(),
-            Some("ArgsTextboxChange".to_string()),
-        );
-        map.insert("click".to_string(), Some("ArgsClick".to_string()));
-        map.insert("mouse_down".to_string(), Some("ArgsMouseDown".to_string()));
-        map.insert("mouse_up".to_string(), Some("ArgsMouseUp".to_string()));
-        map.insert("mouse_move".to_string(), Some("ArgsMouseMove".to_string()));
-        map.insert("mouse_over".to_string(), Some("ArgsMouseOver".to_string()));
-        map.insert("mouse_out".to_string(), Some("ArgsMouseOut".to_string()));
-        map.insert(
-            "double_click".to_string(),
-            Some("ArgsDoubleClick".to_string()),
-        );
-        map.insert(
-            "context_menu".to_string(),
-            Some("ArgsContextMenu".to_string()),
-        );
-        map.insert("wheel".to_string(), Some("ArgsWheel".to_string()));
+        let mut add = |from: &str, to: &str| {
+            map.insert(from.to_owned(), Some(to.to_owned()));
+        };
+        add("scroll", "ArgsScroll");
+        add("clap", "ArgsClap");
+        add("touch_start", "ArgsTouchStart");
+        add("touch_move", "ArgsTouchMove");
+        add("touch_end", "ArgsTouchEnd");
+        add("key_down", "ArgsKeyDown");
+        add("key_up", "ArgsKeyUp");
+        add("key_press", "ArgsKeyPress");
+        add("checkbox_change", "ArgsCheckboxChange");
+        add("button_click", "ArgsButtonClick");
+        add("textbox_change", "ArgsTextboxChange");
+        add("textbox_input", "ArgsTextboxInput");
+        add("click", "ArgsClick");
+        add("mouse_down", "ArgsMouseDown");
+        add("mouse_up", "ArgsMouseUp");
+        add("mouse_move", "ArgsMouseMove");
+        add("mouse_over", "ArgsMouseOver");
+        add("mouse_out", "ArgsMouseOut");
+        add("double_click", "ArgsDoubleClick");
+        add("context_menu", "ArgsContextMenu");
+        add("wheel", "ArgsWheel");
         map.insert("pre_render".to_string(), None);
         map.insert("mount".to_string(), None);
         map.insert("tick".to_string(), None);

--- a/pax-manifest/src/utils.rs
+++ b/pax-manifest/src/utils.rs
@@ -12,7 +12,8 @@ pub fn parse_value(raw_value: &str) -> Result<ValueDefinition, &str> {
     if raw_value.is_empty() {
         return Err("raw value cannot be empty");
     }
-    let mut values = PaxParser::parse(Rule::any_template_value, raw_value).unwrap();
+    let mut values =
+        PaxParser::parse(Rule::any_template_value, raw_value).map_err(|_| "couldn't parse")?;
     if values.as_str() != raw_value {
         return Err("no rule matched entire raw value");
     }

--- a/pax-message/src/lib.rs
+++ b/pax-message/src/lib.rs
@@ -57,6 +57,7 @@ pub enum NativeInterrupt {
     AddedLayer(AddedLayerArgs),
     FormCheckboxToggle(FormCheckboxToggleArgs),
     FormTextboxChange(FormTextboxChangeArgs),
+    FormTextboxInput(FormTextboxInputArgs),
     FormButtonClick(FormButtonClickArgs),
 }
 
@@ -70,6 +71,13 @@ pub struct FormCheckboxToggleArgs {
 #[derive(Deserialize)]
 #[repr(C)]
 pub struct FormTextboxChangeArgs {
+    pub text: String,
+    pub id_chain: Vec<u32>,
+}
+
+#[derive(Deserialize)]
+#[repr(C)]
+pub struct FormTextboxInputArgs {
     pub text: String,
     pub id_chain: Vec<u32>,
 }

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -332,6 +332,11 @@ pub struct ArgsTextboxChange {
 }
 
 #[derive(Clone)]
+pub struct ArgsTextboxInput {
+    pub text: String,
+}
+
+#[derive(Clone)]
 pub struct ArgsButtonClick {}
 
 /// User presses a mouse button over an element.

--- a/pax-runtime/src/constants.rs
+++ b/pax-runtime/src/constants.rs
@@ -9,6 +9,7 @@ pub const KEY_PRESS_HANDLERS: &str = "key_press";
 pub const CHECKBOX_CHANGE_HANDLERS: &str = "checkbox_change";
 pub const BUTTON_CLICK_HANDLERS: &str = "button_click";
 pub const TEXTBOX_CHANGE_HANDLERS: &str = "textbox_change";
+pub const TEXTBOX_INPUT_HANDLERS: &str = "textbox_input";
 pub const CLICK_HANDLERS: &str = "click";
 pub const MOUSE_DOWN_HANDLERS: &str = "mouse_down";
 pub const MOUSE_UP_HANDLERS: &str = "mouse_up";

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -3,7 +3,8 @@ use crate::constants::{
     CONTEXT_MENU_HANDLERS, DOUBLE_CLICK_HANDLERS, KEY_DOWN_HANDLERS, KEY_PRESS_HANDLERS,
     KEY_UP_HANDLERS, MOUSE_DOWN_HANDLERS, MOUSE_MOVE_HANDLERS, MOUSE_OUT_HANDLERS,
     MOUSE_OVER_HANDLERS, MOUSE_UP_HANDLERS, SCROLL_HANDLERS, TEXTBOX_CHANGE_HANDLERS,
-    TOUCH_END_HANDLERS, TOUCH_MOVE_HANDLERS, TOUCH_START_HANDLERS, WHEEL_HANDLERS,
+    TEXTBOX_INPUT_HANDLERS, TOUCH_END_HANDLERS, TOUCH_MOVE_HANDLERS, TOUCH_START_HANDLERS,
+    WHEEL_HANDLERS,
 };
 use crate::Globals;
 #[cfg(debug_assertions)]
@@ -17,8 +18,9 @@ use kurbo::Point;
 use crate::api::{
     ArgsButtonClick, ArgsCheckboxChange, ArgsClap, ArgsClick, ArgsContextMenu, ArgsDoubleClick,
     ArgsKeyDown, ArgsKeyPress, ArgsKeyUp, ArgsMouseDown, ArgsMouseMove, ArgsMouseOut,
-    ArgsMouseOver, ArgsMouseUp, ArgsScroll, ArgsTextboxChange, ArgsTouchEnd, ArgsTouchMove,
-    ArgsTouchStart, ArgsWheel, Axis, CommonProperties, NodeContext, RenderContext, Size,
+    ArgsMouseOver, ArgsMouseUp, ArgsScroll, ArgsTextboxChange, ArgsTextboxInput, ArgsTouchEnd,
+    ArgsTouchMove, ArgsTouchStart, ArgsWheel, Axis, CommonProperties, NodeContext, RenderContext,
+    Size,
 };
 
 use crate::{
@@ -501,6 +503,11 @@ impl ExpandedNode {
         dispatch_textbox_change,
         ArgsTextboxChange,
         TEXTBOX_CHANGE_HANDLERS
+    );
+    dispatch_event_handler!(
+        dispatch_textbox_input,
+        ArgsTextboxInput,
+        TEXTBOX_INPUT_HANDLERS
     );
     dispatch_event_handler!(
         dispatch_button_click,


### PR DESCRIPTION
This renames the old @textbox_change event to @textbox_input (fires on every keystroke), and introduces a new @textbox_change event that fires on enter/textbox de-selection.