### PR TITLE
Keyboard input + Math fixes

### DIFF
--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -120,22 +120,22 @@ pub extern "C" fn pax_interrupt(
                 _ => {}
             };
         }
-        NativeInterrupt::Scroll(args) => {
-            let prospective_hit = engine.get_focused_element();
-            match prospective_hit {
-                Some(topmost_node) => {
-                    let args_scroll = ArgsScroll {
-                        delta_x: args.delta_x,
-                        delta_y: args.delta_y,
-                    };
-                    topmost_node.dispatch_scroll(
-                        args_scroll,
-                        engine.runtime_context.globals(),
-                        &engine.runtime_context,
-                    );
-                }
-                _ => {}
-            };
+        NativeInterrupt::Scroll(_args) => {
+            // let prospective_hit = engine.get_focused_element();
+            // match prospective_hit {
+            //     Some(topmost_node) => {
+            //         let args_scroll = ArgsScroll {
+            //             delta_x: args.delta_x,
+            //             delta_y: args.delta_y,
+            //         };
+            //         topmost_node.dispatch_scroll(
+            //             args_scroll,
+            //             engine.runtime_context.globals(),
+            //             &engine.runtime_context,
+            //         );
+            //     }
+            //     _ => {}
+            // };
         }
         NativeInterrupt::Image(args) => match args {
             ImageLoadInterruptArgs::Reference(_ref_args) => {

--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -120,23 +120,7 @@ pub extern "C" fn pax_interrupt(
                 _ => {}
             };
         }
-        NativeInterrupt::Scroll(_args) => {
-            // let prospective_hit = engine.get_focused_element();
-            // match prospective_hit {
-            //     Some(topmost_node) => {
-            //         let args_scroll = ArgsScroll {
-            //             delta_x: args.delta_x,
-            //             delta_y: args.delta_y,
-            //         };
-            //         topmost_node.dispatch_scroll(
-            //             args_scroll,
-            //             engine.runtime_context.globals(),
-            //             &engine.runtime_context,
-            //         );
-            //     }
-            //     _ => {}
-            // };
-        }
+        NativeInterrupt::Scroll(_args) => {}
         NativeInterrupt::Image(args) => match args {
             ImageLoadInterruptArgs::Reference(_ref_args) => {
                 // TODO this needs to be redone since image_map now lives in the

--- a/pax-chassis-web/interface/src/events/listeners.ts
+++ b/pax-chassis-web/interface/src/events/listeners.ts
@@ -19,7 +19,7 @@ function getMouseButton(event: MouseEvent) {
 }
 
 
-export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
+export function setupEventListeners(chassis: PaxChassisWeb) {
 
     let lastPositions = new Map<number, {x: number, y: number}>();
     // @ts-ignore
@@ -40,7 +40,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
     }
 
     // @ts-ignore
-    layer.addEventListener('click', (evt) => {
+    window.addEventListener('click', (evt) => {
 
         let clickEvent = {
             "Click": {
@@ -60,7 +60,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(clapEvent), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('dblclick', (evt) => {
+    window.addEventListener('dblclick', (evt) => {
         let event = {
             "DoubleClick": {
                 "x": evt.clientX,
@@ -72,7 +72,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('mousemove', (evt) => {
+    window.addEventListener('mousemove', (evt) => {
         // @ts-ignore
         let button = window.current_button || 'Left';
         let event = {
@@ -86,7 +86,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('wheel', (evt) => {
+    window.addEventListener('wheel', (evt) => {
         let event = {
             "Wheel": {
                 "x": evt.clientX,
@@ -99,7 +99,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, {"passive": true, "capture": true});
     // @ts-ignore
-    layer.addEventListener('mousedown', (evt) => {
+    window.addEventListener('mousedown', (evt) => {
         let button = getMouseButton(evt);
         // @ts-ignore
         window.current_button = button;
@@ -114,7 +114,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('mouseup', (evt) => {
+    window.addEventListener('mouseup', (evt) => {
         let event = {
             "MouseUp": {
                 "x": evt.clientX,
@@ -126,7 +126,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('mouseover', (evt) => {
+    window.addEventListener('mouseover', (evt) => {
         let event = {
             "MouseOver": {
                 "x": evt.clientX,
@@ -138,7 +138,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('mouseout', (evt) => {
+    window.addEventListener('mouseout', (evt) => {
         let event = {
             "MouseOut": {
                 "x": evt.clientX,
@@ -150,7 +150,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('contextmenu', (evt) => {
+    window.addEventListener('contextmenu', (evt) => {
         let event = {
             "ContextMenu": {
                 "x": evt.clientX,
@@ -162,7 +162,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('touchstart', (evt) => {
+    window.addEventListener('touchstart', (evt) => {
         let event = {
             "TouchStart": {
                 "touches": getTouchMessages(evt.touches)
@@ -182,7 +182,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(clapEvent), []);
     }, {"passive": true, "capture": true});
     // @ts-ignore
-    layer.addEventListener('touchmove', (evt) => {
+    window.addEventListener('touchmove', (evt) => {
         let touches = getTouchMessages(evt.touches);
         let event = {
             "TouchMove": {
@@ -193,7 +193,7 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
 
     }, {"passive": true, "capture": true});
     // @ts-ignore
-    layer.addEventListener('touchend', (evt) => {
+    window.addEventListener('touchend', (evt) => {
         let event = {
             "TouchEnd": {
                 "touches": getTouchMessages(evt.changedTouches)
@@ -205,7 +205,10 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         });
     }, {"passive": true, "capture": true});
     // @ts-ignore
-    layer.addEventListener('keydown', (evt) => {
+    window.addEventListener('keydown', (evt) => {
+        if (document.activeElement != document.body) {
+            return;
+        }
         let event = {
             "KeyDown": {
                 "key": evt.key,
@@ -216,7 +219,10 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('keyup', (evt) => {
+    window.addEventListener('keyup', (evt) => {
+        if (document.activeElement != document.body) {
+            return;
+        }
         let event = {
             "KeyUp": {
                 "key": evt.key,
@@ -227,7 +233,10 @@ export function setupEventListeners(chassis: PaxChassisWeb, layer: any) {
         chassis.interrupt(JSON.stringify(event), []);
     }, true);
     // @ts-ignore
-    layer.addEventListener('keypress', (evt) => {
+    window.addEventListener('keypress', (evt) => {
+        if (document.activeElement != document.body) {
+            return;
+        }
         let event = {
             "KeyPress": {
                 "key": evt.key,

--- a/pax-chassis-web/interface/src/index.ts
+++ b/pax-chassis-web/interface/src/index.ts
@@ -104,7 +104,7 @@ function renderLoop (chassis: PaxChassisWeb, mount: Element, get_latest_memory: 
         };
         window.addEventListener('resize', resizeHandler);
         resizeHandler();//Fire once manually to init viewport size & occlusion context
-        setupEventListeners(chassis, mount);
+        setupEventListeners(chassis);
         initializedChassis = true;
     }
 

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -224,16 +224,7 @@ impl PaxChassisWeb {
                     topmost_node.dispatch_click(args_click, globals, &engine.runtime_context);
                 }
             }
-            NativeInterrupt::Scroll(_args) => {
-                // let prospective_hit = engine.get_focused_element();
-                // if let Some(topmost_node) = prospective_hit {
-                //     let args_scroll = ArgsScroll {
-                //         delta_x: args.delta_x,
-                //         delta_y: args.delta_y,
-                //     };
-                //     topmost_node.dispatch_scroll(args_scroll, globals, &engine.runtime_context);
-                // }
-            }
+            NativeInterrupt::Scroll(_args) => {}
             NativeInterrupt::Clap(args) => {
                 let prospective_hit = engine
                     .runtime_context

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -224,15 +224,15 @@ impl PaxChassisWeb {
                     topmost_node.dispatch_click(args_click, globals, &engine.runtime_context);
                 }
             }
-            NativeInterrupt::Scroll(args) => {
-                let prospective_hit = engine.get_focused_element();
-                if let Some(topmost_node) = prospective_hit {
-                    let args_scroll = ArgsScroll {
-                        delta_x: args.delta_x,
-                        delta_y: args.delta_y,
-                    };
-                    topmost_node.dispatch_scroll(args_scroll, globals, &engine.runtime_context);
-                }
+            NativeInterrupt::Scroll(_args) => {
+                // let prospective_hit = engine.get_focused_element();
+                // if let Some(topmost_node) = prospective_hit {
+                //     let args_scroll = ArgsScroll {
+                //         delta_x: args.delta_x,
+                //         delta_y: args.delta_y,
+                //     };
+                //     topmost_node.dispatch_scroll(args_scroll, globals, &engine.runtime_context);
+                // }
             }
             NativeInterrupt::Clap(args) => {
                 let prospective_hit = engine
@@ -292,62 +292,49 @@ impl PaxChassisWeb {
                 }
             }
             NativeInterrupt::KeyDown(args) => {
-                let prospective_hit = engine.get_focused_element();
-                if let Some(topmost_node) = prospective_hit {
-                    let modifiers = args
-                        .modifiers
-                        .iter()
-                        .map(|x| ModifierKey::from(x))
-                        .collect();
-                    let args_key_down = ArgsKeyDown {
-                        keyboard: KeyboardEventArgs {
-                            key: args.key,
-                            modifiers,
-                            is_repeat: args.is_repeat,
-                        },
-                    };
-                    topmost_node.dispatch_key_down(args_key_down, globals, &engine.runtime_context);
-                }
+                let modifiers = args
+                    .modifiers
+                    .iter()
+                    .map(|x| ModifierKey::from(x))
+                    .collect();
+                let args_key_down = ArgsKeyDown {
+                    keyboard: KeyboardEventArgs {
+                        key: args.key,
+                        modifiers,
+                        is_repeat: args.is_repeat,
+                    },
+                };
+                engine.global_dispatch_key_down(args_key_down);
             }
             NativeInterrupt::KeyUp(args) => {
-                let prospective_hit = engine.get_focused_element();
-                if let Some(topmost_node) = prospective_hit {
-                    let modifiers = args
-                        .modifiers
-                        .iter()
-                        .map(|x| ModifierKey::from(x))
-                        .collect();
-                    let args_key_up = ArgsKeyUp {
-                        keyboard: KeyboardEventArgs {
-                            key: args.key,
-                            modifiers,
-                            is_repeat: args.is_repeat,
-                        },
-                    };
-                    topmost_node.dispatch_key_up(args_key_up, globals, &engine.runtime_context);
-                }
+                let modifiers = args
+                    .modifiers
+                    .iter()
+                    .map(|x| ModifierKey::from(x))
+                    .collect();
+                let args_key_up = ArgsKeyUp {
+                    keyboard: KeyboardEventArgs {
+                        key: args.key,
+                        modifiers,
+                        is_repeat: args.is_repeat,
+                    },
+                };
+                engine.global_dispatch_key_up(args_key_up);
             }
             NativeInterrupt::KeyPress(args) => {
-                let prospective_hit = engine.get_focused_element();
-                if let Some(topmost_node) = prospective_hit {
-                    let modifiers = args
-                        .modifiers
-                        .iter()
-                        .map(|x| ModifierKey::from(x))
-                        .collect();
-                    let args_key_press = ArgsKeyPress {
-                        keyboard: KeyboardEventArgs {
-                            key: args.key,
-                            modifiers,
-                            is_repeat: args.is_repeat,
-                        },
-                    };
-                    topmost_node.dispatch_key_press(
-                        args_key_press,
-                        globals,
-                        &engine.runtime_context,
-                    );
-                }
+                let modifiers = args
+                    .modifiers
+                    .iter()
+                    .map(|x| ModifierKey::from(x))
+                    .collect();
+                let args_key_press = ArgsKeyPress {
+                    keyboard: KeyboardEventArgs {
+                        key: args.key,
+                        modifiers,
+                        is_repeat: args.is_repeat,
+                    },
+                };
+                engine.global_dispatch_key_press(args_key_press);
             }
             NativeInterrupt::DoubleClick(args) => {
                 let prospective_hit = engine

--- a/pax-engine/src/lib.rs
+++ b/pax-engine/src/lib.rs
@@ -4,6 +4,7 @@ pub use pax_macro::*;
 pub use log;
 pub use pax_runtime::api;
 pub use pax_runtime::engine::node_interface::*;
+pub use pax_runtime::layout;
 pub use pax_runtime::math;
 pub use pax_runtime::rendering;
 

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -592,7 +592,7 @@ impl CommonProperties {
 }
 
 #[cfg_attr(debug_assertions, derive(Debug))]
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum Rotation {
     Radians(Numeric),
     Degrees(Numeric),
@@ -758,7 +758,7 @@ impl Mul for Size {
 ///             to be offset either by a pixel or percentage-of-element-size
 ///             for each of (x,y)
 #[cfg_attr(debug_assertions, derive(Debug))]
-#[derive(Default, Clone, Deserialize)]
+#[derive(Default, Clone, Deserialize, Serialize)]
 pub struct Transform2D {
     /// Keeps track of a linked list of previous Transform2Ds, assembled e.g. via multiplication
     pub previous: Option<Box<Transform2D>>,
@@ -769,6 +769,8 @@ pub struct Transform2D {
     pub scale: Option<[Size; 2]>,
     pub skew: Option<[f64; 2]>,
 }
+
+impl Interpolatable for Transform2D {}
 
 impl Mul for Transform2D {
     type Output = Transform2D;

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -154,9 +154,9 @@ impl Space for Window {}
 #[cfg(feature = "designtime")]
 impl NodeContext<'_> {
     pub fn raycast(&self, point: Point2<Window>) -> Vec<NodeInterface> {
-        let expanded_nodes =
-            self.runtime_context
-                .get_elements_beneath_ray(point.cast_space(), false, vec![]);
+        let expanded_nodes = self
+            .runtime_context
+            .get_elements_beneath_ray(point, false, vec![]);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)

--- a/pax-runtime/src/api.rs
+++ b/pax-runtime/src/api.rs
@@ -156,7 +156,7 @@ impl NodeContext<'_> {
     pub fn raycast(&self, point: Point2<Window>) -> Vec<NodeInterface> {
         let expanded_nodes =
             self.runtime_context
-                .get_elements_beneath_ray(point.to_world(), false, vec![]);
+                .get_elements_beneath_ray(point.cast_space(), false, vec![]);
         expanded_nodes
             .into_iter()
             .map(Into::<NodeInterface>::into)

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -19,7 +19,7 @@ use crate::api::{
     ArgsKeyDown, ArgsKeyPress, ArgsKeyUp, ArgsMouseDown, ArgsMouseMove, ArgsMouseOut,
     ArgsMouseOver, ArgsMouseUp, ArgsScroll, ArgsTextboxChange, ArgsTextboxInput, ArgsTouchEnd,
     ArgsTouchMove, ArgsTouchStart, ArgsWheel, Axis, CommonProperties, NodeContext, RenderContext,
-    Size,
+    Size, Window,
 };
 
 use crate::{
@@ -418,7 +418,7 @@ impl ExpandedNode {
 
     /// Determines whether the provided ray, orthogonal to the view plane,
     /// intersects this `ExpandedNode`.
-    pub fn ray_cast_test(&self, ray: Point2) -> bool {
+    pub fn ray_cast_test(&self, ray: Point2<Window>) -> bool {
         // Don't vacuously hit for `invisible_to_raycasting` nodes
         if self.instance_node.base().flags().invisible_to_raycasting {
             return false;

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -90,7 +90,7 @@ pub struct ExpandedNode {
 }
 
 macro_rules! dispatch_event_handler {
-    ($fn_name:ident, $arg_type:ty, $handler_key:ident) => {
+    ($fn_name:ident, $arg_type:ty, $handler_key:ident, $recurse:expr) => {
         pub fn $fn_name(&self, args: $arg_type, globals: &Globals, ctx: &RuntimeContext) {
             if let Some(registry) = self.instance_node.base().get_handler_registry() {
                 let component_properties = if let Some(cc) = self.containing_component.upgrade() {
@@ -137,8 +137,10 @@ macro_rules! dispatch_event_handler {
                 };
             }
 
-            if let Some(parent) = &self.parent_expanded_node.borrow().upgrade() {
-                parent.$fn_name(args, globals, ctx);
+            if $recurse {
+                if let Some(parent) = &self.parent_expanded_node.borrow().upgrade() {
+                    parent.$fn_name(args, globals, ctx);
+                }
             }
         }
     };
@@ -489,52 +491,83 @@ impl ExpandedNode {
         }
     }
 
-    dispatch_event_handler!(dispatch_scroll, ArgsScroll, SCROLL_HANDLERS);
-    dispatch_event_handler!(dispatch_clap, ArgsClap, CLAP_HANDLERS);
-    dispatch_event_handler!(dispatch_touch_start, ArgsTouchStart, TOUCH_START_HANDLERS);
+    dispatch_event_handler!(dispatch_scroll, ArgsScroll, SCROLL_HANDLERS, true);
+    dispatch_event_handler!(dispatch_clap, ArgsClap, CLAP_HANDLERS, true);
+    dispatch_event_handler!(
+        dispatch_touch_start,
+        ArgsTouchStart,
+        TOUCH_START_HANDLERS,
+        true
+    );
 
-    dispatch_event_handler!(dispatch_touch_move, ArgsTouchMove, TOUCH_MOVE_HANDLERS);
-    dispatch_event_handler!(dispatch_touch_end, ArgsTouchEnd, TOUCH_END_HANDLERS);
-    dispatch_event_handler!(dispatch_key_down, ArgsKeyDown, KEY_DOWN_HANDLERS);
-    dispatch_event_handler!(dispatch_key_up, ArgsKeyUp, KEY_UP_HANDLERS);
-    dispatch_event_handler!(dispatch_key_press, ArgsKeyPress, KEY_PRESS_HANDLERS);
+    dispatch_event_handler!(
+        dispatch_touch_move,
+        ArgsTouchMove,
+        TOUCH_MOVE_HANDLERS,
+        true
+    );
+    dispatch_event_handler!(dispatch_touch_end, ArgsTouchEnd, TOUCH_END_HANDLERS, true);
+    dispatch_event_handler!(dispatch_key_down, ArgsKeyDown, KEY_DOWN_HANDLERS, false);
+    dispatch_event_handler!(dispatch_key_up, ArgsKeyUp, KEY_UP_HANDLERS, false);
+    dispatch_event_handler!(dispatch_key_press, ArgsKeyPress, KEY_PRESS_HANDLERS, false);
     dispatch_event_handler!(
         dispatch_checkbox_change,
         ArgsCheckboxChange,
-        CHECKBOX_CHANGE_HANDLERS
+        CHECKBOX_CHANGE_HANDLERS,
+        true
     );
     dispatch_event_handler!(
         dispatch_textbox_change,
         ArgsTextboxChange,
-        TEXTBOX_CHANGE_HANDLERS
+        TEXTBOX_CHANGE_HANDLERS,
+        true
     );
     dispatch_event_handler!(
         dispatch_textbox_input,
         ArgsTextboxInput,
-        TEXTBOX_INPUT_HANDLERS
+        TEXTBOX_INPUT_HANDLERS,
+        true
     );
     dispatch_event_handler!(
         dispatch_button_click,
         ArgsButtonClick,
-        BUTTON_CLICK_HANDLERS
+        BUTTON_CLICK_HANDLERS,
+        true
     );
-    dispatch_event_handler!(dispatch_mouse_down, ArgsMouseDown, MOUSE_DOWN_HANDLERS);
-    dispatch_event_handler!(dispatch_mouse_up, ArgsMouseUp, MOUSE_UP_HANDLERS);
-    dispatch_event_handler!(dispatch_mouse_move, ArgsMouseMove, MOUSE_MOVE_HANDLERS);
-    dispatch_event_handler!(dispatch_mouse_over, ArgsMouseOver, MOUSE_OVER_HANDLERS);
-    dispatch_event_handler!(dispatch_mouse_out, ArgsMouseOut, MOUSE_OUT_HANDLERS);
+    dispatch_event_handler!(
+        dispatch_mouse_down,
+        ArgsMouseDown,
+        MOUSE_DOWN_HANDLERS,
+        true
+    );
+    dispatch_event_handler!(dispatch_mouse_up, ArgsMouseUp, MOUSE_UP_HANDLERS, true);
+    dispatch_event_handler!(
+        dispatch_mouse_move,
+        ArgsMouseMove,
+        MOUSE_MOVE_HANDLERS,
+        true
+    );
+    dispatch_event_handler!(
+        dispatch_mouse_over,
+        ArgsMouseOver,
+        MOUSE_OVER_HANDLERS,
+        true
+    );
+    dispatch_event_handler!(dispatch_mouse_out, ArgsMouseOut, MOUSE_OUT_HANDLERS, true);
     dispatch_event_handler!(
         dispatch_double_click,
         ArgsDoubleClick,
-        DOUBLE_CLICK_HANDLERS
+        DOUBLE_CLICK_HANDLERS,
+        true
     );
     dispatch_event_handler!(
         dispatch_context_menu,
         ArgsContextMenu,
-        CONTEXT_MENU_HANDLERS
+        CONTEXT_MENU_HANDLERS,
+        true
     );
-    dispatch_event_handler!(dispatch_click, ArgsClick, CLICK_HANDLERS);
-    dispatch_event_handler!(dispatch_wheel, ArgsWheel, WHEEL_HANDLERS);
+    dispatch_event_handler!(dispatch_click, ArgsClick, CLICK_HANDLERS, true);
+    dispatch_event_handler!(dispatch_wheel, ArgsWheel, WHEEL_HANDLERS, true);
 }
 
 /// Properties that are currently re-computed each frame before rendering.

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -8,10 +8,9 @@ use std::rc::Rc;
 use pax_message::{NativeMessage, OcclusionPatch};
 
 use crate::api::{
-    CommonProperties, Interpolatable, Layer, NodeContext, OcclusionLayerGen, RenderContext,
-    TransitionManager,
+    ArgsKeyDown, ArgsKeyPress, ArgsKeyUp, CommonProperties, Interpolatable, Layer, NodeContext,
+    OcclusionLayerGen, RenderContext, TransitionManager,
 };
-use crate::math::Point2;
 use piet::InterpolationMode;
 
 use crate::declarative_macros::{handle_vtable_update, handle_vtable_update_optional};
@@ -414,14 +413,47 @@ impl PaxEngine {
         self.runtime_context.node_cache.get(&id)
     }
 
-    pub fn get_focused_element(&self) -> Option<Rc<ExpandedNode>> {
-        let (x, y) = self.runtime_context.globals().viewport.bounds;
-        self.runtime_context
-            .get_topmost_element_beneath_ray(Point2::new(x / 2.0, y / 2.0))
-    }
-
     /// Called by chassis when viewport size changes, e.g. with native window resizes
     pub fn set_viewport_size(&mut self, new_viewport_size: (f64, f64)) {
         self.runtime_context.globals_mut().viewport.bounds = new_viewport_size;
+    }
+
+    pub fn global_dispatch_key_down(&self, args: ArgsKeyDown) {
+        self.root_node.recurse_visit_postorder(
+            &|expanded_node, _| {
+                expanded_node.dispatch_key_down(
+                    args.clone(),
+                    self.runtime_context.globals(),
+                    &self.runtime_context,
+                )
+            },
+            &mut (),
+        );
+    }
+
+    pub fn global_dispatch_key_up(&self, args: ArgsKeyUp) {
+        self.root_node.recurse_visit_postorder(
+            &|expanded_node, _| {
+                expanded_node.dispatch_key_up(
+                    args.clone(),
+                    self.runtime_context.globals(),
+                    &self.runtime_context,
+                )
+            },
+            &mut (),
+        );
+    }
+
+    pub fn global_dispatch_key_press(&self, args: ArgsKeyPress) {
+        self.root_node.recurse_visit_postorder(
+            &|expanded_node, _| {
+                expanded_node.dispatch_key_press(
+                    args.clone(),
+                    self.runtime_context.globals(),
+                    &self.runtime_context,
+                )
+            },
+            &mut (),
+        );
     }
 }

--- a/pax-runtime/src/engine/node_interface.rs
+++ b/pax-runtime/src/engine/node_interface.rs
@@ -45,14 +45,14 @@ impl NodeInterface {
                 .map(|y| y.get().get_pixels(tab.bounds.1))
                 .unwrap_or(0.0),
         );
-        let origin_window: Point2<Window> = (tab.transform * p_anchor).to_world();
+        let origin_window: Point2<Window> = (tab.transform * p_anchor).cast_space();
         Some(origin_window)
     }
 
     pub fn transform(&self) -> Option<Transform2<Window, NodeLocal>> {
         let up_lp = self.inner.layout_properties.borrow_mut();
         if let Some(lp) = up_lp.as_ref() {
-            Some(lp.computed_tab.transform.inverse().between_worlds())
+            Some(lp.computed_tab.transform.inverse().cast_spaces())
         } else {
             None
         }
@@ -61,7 +61,7 @@ impl NodeInterface {
     pub fn bounding_points(&self) -> Option<[Point2<Window>; 4]> {
         let lp = self.inner.layout_properties.borrow();
         if let Some(layout) = lp.as_ref() {
-            Some(layout.computed_tab.corners().map(Point2::to_world))
+            Some(layout.computed_tab.corners().map(Point2::cast_space))
         } else {
             None
         }

--- a/pax-runtime/src/engine/node_interface.rs
+++ b/pax-runtime/src/engine/node_interface.rs
@@ -45,14 +45,14 @@ impl NodeInterface {
                 .map(|y| y.get().get_pixels(tab.bounds.1))
                 .unwrap_or(0.0),
         );
-        let origin_window: Point2<Window> = (tab.transform * p_anchor).cast_space();
+        let origin_window = tab.transform * p_anchor;
         Some(origin_window)
     }
 
     pub fn transform(&self) -> Option<Transform2<Window, NodeLocal>> {
         let up_lp = self.inner.layout_properties.borrow_mut();
         if let Some(lp) = up_lp.as_ref() {
-            Some(lp.computed_tab.transform.inverse().cast_spaces())
+            Some(lp.computed_tab.transform.inverse())
         } else {
             None
         }
@@ -61,7 +61,7 @@ impl NodeInterface {
     pub fn bounding_points(&self) -> Option<[Point2<Window>; 4]> {
         let lp = self.inner.layout_properties.borrow();
         if let Some(layout) = lp.as_ref() {
-            Some(layout.computed_tab.corners().map(Point2::cast_space))
+            Some(layout.computed_tab.corners())
         } else {
             None
         }

--- a/pax-runtime/src/layout.rs
+++ b/pax-runtime/src/layout.rs
@@ -1,5 +1,6 @@
 use crate::api::{Axis, Size, Transform2D};
 use crate::math::{Generic, Transform2, Vector2};
+use crate::node_interface::NodeLocal;
 use crate::{ExpandedNode, TransformAndBounds};
 
 /// For the `current_expanded_node` attached to `ptc`, calculates and returns a new [`crate::rendering::TransformAndBounds`] a.k.a. "tab".
@@ -20,6 +21,7 @@ pub fn compute_tab(node: &ExpandedNode, container_tab: &TransformAndBounds) -> T
                 new_accumulated_bounds_and_current_node_size.clone(),
                 container_tab.bounds,
             )
+            .cast_spaces::<NodeLocal, NodeLocal>()
     };
 
     // From a combination of the sugared TemplateNodeDefinition properties like `width`, `height`, `x`, `y`, `scale_x`, etc.
@@ -92,10 +94,12 @@ pub fn compute_tab(node: &ExpandedNode, container_tab: &TransformAndBounds) -> T
         };
         desugared_transform2d.rotate = Some(rotate);
 
-        desugared_transform2d.compute_transform2d_matrix(
-            new_accumulated_bounds_and_current_node_size.clone(),
-            container_tab.bounds,
-        )
+        desugared_transform2d
+            .compute_transform2d_matrix(
+                new_accumulated_bounds_and_current_node_size.clone(),
+                container_tab.bounds,
+            )
+            .cast_spaces::<NodeLocal, NodeLocal>()
     };
 
     let new_accumulated_transform =
@@ -137,7 +141,7 @@ impl ComputableTransform for Transform2D {
 
         // Compute anchor
         let anchor_transform = match &self.anchor {
-            Some(anchor) => Transform2::<Generic>::translate(Vector2::new(
+            Some(anchor) => Transform2::translate(Vector2::<Generic>::new(
                 match anchor[0] {
                     Size::Pixels(pix) => -pix.get_as_float(),
                     Size::Percent(per) => -node_size.0 * (per / 100.0),

--- a/pax-runtime/src/math/point.rs
+++ b/pax-runtime/src/math/point.rs
@@ -14,6 +14,12 @@ pub struct Point2<W = Generic> {
 // Implement Clone, Copy, PartialEq, etc manually, as
 // to not require the Space to implement these.
 
+impl<W: Space> std::fmt::Debug for Point2<W> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({} {})", self.x, self.y)
+    }
+}
+
 impl<W: Space> Clone for Point2<W> {
     fn clone(&self) -> Self {
         Self {
@@ -82,5 +88,12 @@ impl<W: Space> Add<Point2<W>> for Vector2<W> {
     type Output = Point2<W>;
     fn add(self, rhs: Point2<W>) -> Self::Output {
         Self::Output::new(self.x + rhs.x, self.y + rhs.y)
+    }
+}
+
+impl<W: Space> Sub<Vector2<W>> for Point2<W> {
+    type Output = Point2<W>;
+    fn sub(self, rhs: Vector2<W>) -> Self::Output {
+        Self::Output::new(self.x - rhs.x, self.y - rhs.y)
     }
 }

--- a/pax-runtime/src/math/point.rs
+++ b/pax-runtime/src/math/point.rs
@@ -57,7 +57,7 @@ impl<W: Space> Point2<W> {
         Vector2::new(self.x, self.y)
     }
 
-    pub fn to_world<WNew: Space>(self) -> Point2<WNew> {
+    pub fn cast_space<WNew: Space>(self) -> Point2<WNew> {
         Point2::new(self.x, self.y)
     }
 

--- a/pax-runtime/src/math/transform.rs
+++ b/pax-runtime/src/math/transform.rs
@@ -30,8 +30,8 @@ impl<F: Space, T: Space> Clone for Transform2<F, T> {
 
 impl<F: Space, T: Space> std::fmt::Debug for Transform2<F, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {} {}", self.m[0], self.m[1], self.m[2])?;
-        write!(f, "{} {} {}", self.m[3], self.m[4], self.m[5])
+        writeln!(f, "{} {} {}", self.m[0], self.m[2], self.m[4])?;
+        write!(f, "{} {} {}", self.m[1], self.m[3], self.m[5])
     }
 }
 
@@ -71,7 +71,7 @@ impl<WFrom: Space, WTo: Space> Transform2<WFrom, WTo> {
         Self::new([c, s, -s, c, 0.0, 0.0])
     }
 
-    pub fn translate(p: Vector2<WFrom>) -> Self {
+    pub fn translate(p: Vector2<WTo>) -> Self {
         Self::new([1.0, 0.0, 0.0, 1.0, p.x, p.y])
     }
 
@@ -83,8 +83,17 @@ impl<WFrom: Space, WTo: Space> Transform2<WFrom, WTo> {
         self.m
     }
 
-    pub fn get_translation(self) -> Vector2<WTo> {
-        (self * Point2::<WFrom>::default()).to_vector()
+    pub fn get_translation(self) -> Vector2<WFrom> {
+        (self * Point2::<WFrom>::default()).to_world().to_vector()
+    }
+
+    pub fn get_scale(self) -> Vector2<WTo> {
+        self * Vector2::<WFrom>::new(1.0, 1.0)
+    }
+
+    pub fn set_translation(&mut self, t: Point2<WTo>) {
+        self.m[2] = t.x;
+        self.m[5] = t.y;
     }
 
     pub fn between_worlds<W: Space, T: Space>(self) -> Transform2<W, T> {

--- a/pax-runtime/src/math/transform.rs
+++ b/pax-runtime/src/math/transform.rs
@@ -91,11 +91,6 @@ impl<WFrom: Space, WTo: Space> Transform2<WFrom, WTo> {
         self * Vector2::<WFrom>::new(1.0, 1.0)
     }
 
-    pub fn set_translation(&mut self, t: Point2<WTo>) {
-        self.m[2] = t.x;
-        self.m[5] = t.y;
-    }
-
     pub fn cast_spaces<W: Space, T: Space>(self) -> Transform2<W, T> {
         Transform2::new(self.m)
     }

--- a/pax-runtime/src/math/transform.rs
+++ b/pax-runtime/src/math/transform.rs
@@ -84,7 +84,7 @@ impl<WFrom: Space, WTo: Space> Transform2<WFrom, WTo> {
     }
 
     pub fn get_translation(self) -> Vector2<WFrom> {
-        (self * Point2::<WFrom>::default()).to_world().to_vector()
+        (self * Point2::<WFrom>::default()).cast_space().to_vector()
     }
 
     pub fn get_scale(self) -> Vector2<WTo> {
@@ -96,7 +96,7 @@ impl<WFrom: Space, WTo: Space> Transform2<WFrom, WTo> {
         self.m[5] = t.y;
     }
 
-    pub fn between_worlds<W: Space, T: Space>(self) -> Transform2<W, T> {
+    pub fn cast_spaces<W: Space, T: Space>(self) -> Transform2<W, T> {
         Transform2::new(self.m)
     }
 

--- a/pax-runtime/src/math/vector.rs
+++ b/pax-runtime/src/math/vector.rs
@@ -14,6 +14,12 @@ pub struct Vector2<W = Generic> {
 // Implement Clone, Copy, PartialEq, etc manually, as
 // to not require the Space to implement these.
 
+impl<W: Space> std::fmt::Debug for Vector2<W> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<{} {}>", self.x, self.y)
+    }
+}
+
 impl<W: Space> Clone for Vector2<W> {
     fn clone(&self) -> Self {
         Self {

--- a/pax-runtime/src/math/vector.rs
+++ b/pax-runtime/src/math/vector.rs
@@ -73,7 +73,7 @@ impl<W: Space> Vector2<W> {
         Point2::new(self.x, self.y)
     }
 
-    pub fn to_world<WNew: Space>(self) -> Vector2<WNew> {
+    pub fn cast_space<WNew: Space>(self) -> Vector2<WNew> {
         Vector2::new(self.x, self.y)
     }
 }

--- a/pax-runtime/src/properties.rs
+++ b/pax-runtime/src/properties.rs
@@ -1,3 +1,4 @@
+use crate::api::Window;
 use crate::math::Point2;
 use crate::numeric::Numeric;
 use pax_message::NativeMessage;
@@ -81,7 +82,7 @@ impl RuntimeContext {
     /// not register a `hit`, nor will elements that suppress input events.
     pub fn get_elements_beneath_ray(
         &self,
-        ray: Point2,
+        ray: Point2<Window>,
         limit_one: bool,
         mut accum: Vec<Rc<ExpandedNode>>,
     ) -> Vec<Rc<ExpandedNode>> {
@@ -125,7 +126,7 @@ impl RuntimeContext {
     }
 
     /// Alias for `get_elements_beneath_ray` with `limit_one = true`
-    pub fn get_topmost_element_beneath_ray(&self, ray: Point2) -> Option<Rc<ExpandedNode>> {
+    pub fn get_topmost_element_beneath_ray(&self, ray: Point2<Window>) -> Option<Rc<ExpandedNode>> {
         let res = self.get_elements_beneath_ray(ray, true, vec![]);
         if res.len() == 0 {
             None

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -5,8 +5,9 @@ use super::math::Point2;
 use std::iter;
 use std::rc::Rc;
 
-use crate::api::{CommonProperties, RenderContext};
+use crate::api::{CommonProperties, RenderContext, Window};
 use crate::math::Transform2;
+use crate::node_interface::NodeLocal;
 use piet::{Color, StrokeStyle};
 
 use crate::api::{ArgsScroll, Layer, Size};
@@ -38,13 +39,13 @@ pub struct InstantiationArgs {
 #[cfg_attr(debug_assertions, derive(Debug))]
 #[derive(Clone, PartialEq)]
 pub struct TransformAndBounds {
-    pub transform: Transform2,
+    pub transform: Transform2<NodeLocal, Window>,
     pub bounds: (f64, f64),
     // pub clipping_bounds: Option<(f64, f64)>,
 }
 
 impl TransformAndBounds {
-    pub fn corners(&self) -> [Point2; 4] {
+    pub fn corners(&self) -> [Point2<Window>; 4] {
         let width = self.bounds.0;
         let height = self.bounds.1;
 


### PR DESCRIPTION
This redoes keyboard input to trigger all keyboard handlers (temporary solution before a more robust bubbling/capturing system).

These global handlers are quieted down in the case that an input element is selected (such as textbox).

