### PR TITLE
Expose prevent default behaviour on event handlers

### DIFF
--- a/examples/src/camera/src/lib.rs
+++ b/examples/src/camera/src/lib.rs
@@ -26,7 +26,7 @@ impl Camera {
         self.pan_y.set(0.0);
     }
 
-    pub fn handle_click(&mut self, _: NodeContext, args: ArgsClick) {
+    pub fn handle_click(&mut self, _: NodeContext, args: Event<Click>) {
         let delta_pan = (
             args.mouse.x - self.pan_x.get(),
             args.mouse.y - self.pan_y.get(),

--- a/examples/src/component_in_component/src/inner.rs
+++ b/examples/src/component_in_component/src/inner.rs
@@ -19,7 +19,7 @@ pub struct Inner {
 impl Inner {
     pub fn handle_mount(&mut self, ctx: &NodeContext) {}
 
-    pub fn inner_clicked(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn inner_clicked(&mut self, ctx: &NodeContext, args: Event<Click>) {
         self.inner_active.set(!self.inner_active.get());
     }
 }

--- a/examples/src/component_in_component/src/lib.rs
+++ b/examples/src/component_in_component/src/lib.rs
@@ -25,7 +25,7 @@ impl Example {
         self.x.set(Size::Percent(30.into()));
     }
 
-    pub fn outer_clicked(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn outer_clicked(&mut self, ctx: &NodeContext, args: Event<Click>) {
         self.outer_active.set(!self.outer_active.get());
     }
 }

--- a/examples/src/fireworks/src/fireworks.pax
+++ b/examples/src/fireworks/src/fireworks.pax
@@ -1,4 +1,4 @@
-<Group id=hello @wheel=self.handle_scroll >
+<Group id=hello @wheel=self.handle_scroll @context_menu=self.context_menu>
     for i in 0..60 {
         <Rectangle fill={Fill::Solid(Color::hlc(ticks + i * 360.0 / 30.0, 75.0, 150.0))} width=300px height=300px transform={
             Transform2D::anchor(50%, 50%)

--- a/examples/src/fireworks/src/fireworks.pax
+++ b/examples/src/fireworks/src/fireworks.pax
@@ -1,4 +1,4 @@
-<Group id=hello @wheel=self.handle_scroll @context_menu=self.context_menu>
+<Group id=hello @wheel=self.handle_scroll>
     for i in 0..60 {
         <Rectangle fill={Fill::Solid(Color::hlc(ticks + i * 360.0 / 30.0, 75.0, 150.0))} width=300px height=300px transform={
             Transform2D::anchor(50%, 50%)

--- a/examples/src/fireworks/src/lib.rs
+++ b/examples/src/fireworks/src/lib.rs
@@ -20,11 +20,6 @@ impl Fireworks {
         self.rotation.set(f64::max(0.0, new_t));
     }
 
-    pub fn context_menu(&mut self, _ctx: &NodeContext, args: Event<ContextMenu>) {
-        log::info!("clicked!");
-        args.prevent_default();
-    }
-
     pub fn handle_pre_render(&mut self, _ctx: &NodeContext) {
         let old_ticks = self.ticks.get();
         self.ticks.set(old_ticks + 1);

--- a/examples/src/fireworks/src/lib.rs
+++ b/examples/src/fireworks/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(unused_imports)]
-use pax_engine::api::{ArgsClick, ArgsWheel, EasingCurve, NodeContext};
+use pax_engine::api::{Click, ContextMenu, EasingCurve, Event, NodeContext, Wheel};
 use pax_engine::*;
 use pax_std::primitives::{Ellipse, Frame, Group, Path, Rectangle, Text};
 
@@ -14,10 +14,15 @@ pub struct Fireworks {
 const ROTATION_COEFFICIENT: f64 = 0.00010;
 
 impl Fireworks {
-    pub fn handle_scroll(&mut self, _ctx: &NodeContext, args: ArgsWheel) {
+    pub fn handle_scroll(&mut self, _ctx: &NodeContext, args: Event<Wheel>) {
         let old_t = self.rotation.get();
         let new_t = old_t - args.delta_y * ROTATION_COEFFICIENT;
         self.rotation.set(f64::max(0.0, new_t));
+    }
+
+    pub fn context_menu(&mut self, _ctx: &NodeContext, args: Event<ContextMenu>) {
+        log::info!("clicked!");
+        args.prevent_default();
     }
 
     pub fn handle_pre_render(&mut self, _ctx: &NodeContext) {

--- a/examples/src/hello-rgb/src/lib.rs
+++ b/examples/src/hello-rgb/src/lib.rs
@@ -11,7 +11,7 @@ pub struct HelloRGB {
 
 const ROTATION_COEFFICIENT: f64 = 0.005;
 impl HelloRGB {
-    pub fn handle_scroll(&mut self, ctx: &NodeContext, args: ArgsWheel) {
+    pub fn handle_scroll(&mut self, ctx: &NodeContext, args: Event<Wheel>) {
         let old_t = self.rotation.get();
         let new_t = old_t + args.delta_y * ROTATION_COEFFICIENT;
         self.rotation.set(new_t);

--- a/examples/src/layer-tests/src/lib.rs
+++ b/examples/src/layer-tests/src/lib.rs
@@ -27,7 +27,7 @@ impl Example {
         self.ticks.set(old_ticks + 1);
     }
 
-    pub fn toggle(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn toggle(&mut self, ctx: &NodeContext, args: Event<Click>) {
         self.activated.set(!self.activated.get());
         self.message.set(format!("{}", self.activated.get()));
     }

--- a/examples/src/paths/src/lib.rs
+++ b/examples/src/paths/src/lib.rs
@@ -26,7 +26,7 @@ impl Example {
         self.ticks.set(old_ticks + 1);
     }
 
-    pub fn increment(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn increment(&mut self, ctx: &NodeContext, args: Event<Click>) {
         let old_num_clicks = self.num_clicks.get();
         self.num_clicks.set(old_num_clicks + 1);
         self.message

--- a/examples/src/pax-intro/src/lib.rs
+++ b/examples/src/pax-intro/src/lib.rs
@@ -93,9 +93,9 @@ impl DynamicObject {
         }
     }
 
-    pub fn increment(&mut self, _ctx: &NodeContext, _args: ArgsClick) {}
+    pub fn increment(&mut self, _ctx: &NodeContext, _args: Event<Click>) {}
 
-    pub fn mouse_move(&mut self, _ctx: &NodeContext, args: ArgsMouseMove) {
+    pub fn mouse_move(&mut self, _ctx: &NodeContext, args: Event<MouseMove>) {
         self.mouse_x.set(args.mouse.x);
         self.mouse_y.set(args.mouse.y);
     }

--- a/examples/src/playground/src/lib.rs
+++ b/examples/src/playground/src/lib.rs
@@ -33,7 +33,7 @@ impl Example {
         self.ticks.set(old_ticks + 1);
     }
 
-    pub fn toggle(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn toggle(&mut self, ctx: &NodeContext, args: Event<Click>) {
         let old_num_clicks = self.num_clicks.get();
         self.num_clicks.set(old_num_clicks + 1);
         self.message
@@ -41,7 +41,7 @@ impl Example {
         self.conditional.set(!self.conditional.get());
     }
 
-    pub fn checkbox_change(&mut self, ctx: &NodeContext, args: ArgsCheckboxChange) {
+    pub fn checkbox_change(&mut self, ctx: &NodeContext, args: Event<CheckboxChange>) {
         self.checked.set(!args.checked);
         self.align_vertical.set(match self.checked.get() {
             true => TextAlignVertical::Top,
@@ -56,11 +56,11 @@ impl Example {
         }
     }
 
-    pub fn textbox_input(&mut self, ctx: &NodeContext, args: ArgsTextboxInput) {
+    pub fn textbox_input(&mut self, ctx: &NodeContext, args: Event<TextboxInput>) {
         self.textbox_text.set(args.text);
     }
 
-    pub fn button_click(&mut self, ctx: &NodeContext, args: ArgsButtonClick) {
+    pub fn button_click(&mut self, ctx: &NodeContext, args: Event<ButtonClick>) {
         self.color
             .set(Color::rgba(1.0.into(), 0.3.into(), 0.6.into(), 1.0.into()));
     }

--- a/examples/src/raycast-tests/src/lib.rs
+++ b/examples/src/raycast-tests/src/lib.rs
@@ -19,23 +19,23 @@ pub struct Example {
 impl Example {
     pub fn handle_mount(&mut self, ctx: &NodeContext) {}
 
-    pub fn frame1(&mut self, ctx: &NodeContext, args: ArgsMouseMove) {
+    pub fn frame1(&mut self, ctx: &NodeContext, args: Event<MouseMove>) {
         self.hit_outer.set(format!("hit outer: frame {}", 1));
     }
 
-    pub fn frame2(&mut self, ctx: &NodeContext, args: ArgsMouseMove) {
+    pub fn frame2(&mut self, ctx: &NodeContext, args: Event<MouseMove>) {
         self.hit_outer.set(format!("hit outer: frame {}", 2));
     }
 
-    pub fn frame1rect1(&mut self, ctx: &NodeContext, args: ArgsMouseMove) {
+    pub fn frame1rect1(&mut self, ctx: &NodeContext, args: Event<MouseMove>) {
         self.hit_inner.set(format!("hit inner: rect {}", 1));
     }
 
-    pub fn frame1rect2(&mut self, ctx: &NodeContext, args: ArgsMouseMove) {
+    pub fn frame1rect2(&mut self, ctx: &NodeContext, args: Event<MouseMove>) {
         self.hit_inner.set(format!("hit inner: rect {}", 2));
     }
 
-    pub fn frame2rect1(&mut self, ctx: &NodeContext, args: ArgsMouseMove) {
+    pub fn frame2rect1(&mut self, ctx: &NodeContext, args: Event<MouseMove>) {
         self.hit_inner.set(format!("hit inner: rect {}", 1));
     }
 }

--- a/examples/src/simple-conditional/src/lib.rs
+++ b/examples/src/simple-conditional/src/lib.rs
@@ -29,7 +29,7 @@ impl Example {
         self.ticks.set(old_ticks + 1);
     }
 
-    pub fn increment(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn increment(&mut self, ctx: &NodeContext, args: Event<Click>) {
         self.activated.set(!self.activated.get());
         self.not_activated.set(!self.activated.get());
         self.message

--- a/examples/src/simple-stacker/src/lib.rs
+++ b/examples/src/simple-stacker/src/lib.rs
@@ -23,15 +23,15 @@ impl Example {
         self.num.set(1);
     }
 
-    pub fn click0(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn click0(&mut self, ctx: &NodeContext, args: Event<Click>) {
         self.num.set(1);
     }
 
-    pub fn click1(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn click1(&mut self, ctx: &NodeContext, args: Event<Click>) {
         self.num.set(3);
     }
 
-    pub fn click2(&mut self, ctx: &NodeContext, args: ArgsClick) {
+    pub fn click2(&mut self, ctx: &NodeContext, args: Event<Click>) {
         self.num.set(5);
     }
     pub fn handle_pre_render(&mut self, ctx: &NodeContext) {}

--- a/examples/src/words/src/lib.rs
+++ b/examples/src/words/src/lib.rs
@@ -1,11 +1,10 @@
 use pax_engine::api::{
-    ArgsClick, ArgsClap, ArgsScroll, ArgsTouchStart, ArgsTouchMove, ArgsTouchEnd,
-    ArgsKeyDown, ArgsKeyUp, ArgsKeyPress, ArgsDoubleClick, ArgsMouseMove, ArgsWheel,
-    ArgsMouseDown, ArgsMouseUp, ArgsMouseOver, ArgsMouseOut, ArgsContextMenu,
-    NodeContext,  Property, PropertyLiteral
+    ArgsClap, ArgsClick, ArgsContextMenu, ArgsDoubleClick, ArgsKeyDown, ArgsKeyPress, ArgsKeyUp,
+    ArgsMouseDown, ArgsMouseMove, ArgsMouseOut, ArgsMouseOver, ArgsMouseUp, ArgsScroll,
+    ArgsTouchEnd, ArgsTouchMove, ArgsTouchStart, ArgsWheel, NodeContext, Property, PropertyLiteral,
 };
 use pax_engine::Pax;
-use pax_std::primitives::{Ellipse, Frame, Group, Path, Rectangle, Text, Image};
+use pax_std::primitives::{Ellipse, Frame, Group, Image, Path, Rectangle, Text};
 use pax_std::types::text::*;
 
 #[pax]
@@ -16,74 +15,73 @@ pub struct Words {
 }
 
 impl Words {
-    pub fn handle_mount(&mut self, _ctx: &NodeContext) {
-    }
+    pub fn handle_mount(&mut self, _ctx: &NodeContext) {}
 
-    pub fn handle_clap(&mut self, _ctx: &NodeContext, _args: ArgsClap) {
+    pub fn handle_clap(&mut self, _ctx: &NodeContext, _args: Event<Clap>) {
         self.content.set("Clap".to_string());
     }
 
-    pub fn handle_scroll(&mut self, _ctx: &NodeContext, _args: ArgsScroll) {
+    pub fn handle_scroll(&mut self, _ctx: &NodeContext, _args: Event<Scroll>) {
         self.content.set("Scroll".to_string());
     }
 
-    pub fn handle_touch_start(&mut self, _ctx: &NodeContext, _args: ArgsTouchStart) {
+    pub fn handle_touch_start(&mut self, _ctx: &NodeContext, _args: Event<TouchStart>) {
         self.content.set("Touch Start".to_string());
     }
 
-    pub fn handle_touch_move(&mut self, _ctx: &NodeContext, _args: ArgsTouchMove) {
+    pub fn handle_touch_move(&mut self, _ctx: &NodeContext, _args: Event<TouchMove>) {
         self.content.set("Touch Move".to_string());
     }
 
-    pub fn handle_touch_end(&mut self, _ctx: &NodeContext, _args: ArgsTouchEnd) {
+    pub fn handle_touch_end(&mut self, _ctx: &NodeContext, _args: Event<TouchEnd>) {
         self.content.set("Touch End".to_string());
     }
 
-    pub fn handle_key_down(&mut self, _ctx: &NodeContext, _args: ArgsKeyDown) {
+    pub fn handle_key_down(&mut self, _ctx: &NodeContext, _args: Event<KeyDown>) {
         self.content.set("Key Down".to_string());
     }
 
-    pub fn handle_key_up(&mut self, _ctx: &NodeContext, _args: ArgsKeyUp) {
+    pub fn handle_key_up(&mut self, _ctx: &NodeContext, _args: Event<KeyUp>) {
         self.content.set("Key Up".to_string());
     }
 
-    pub fn handle_key_press(&mut self, _ctx: &NodeContext, _args: ArgsKeyPress) {
+    pub fn handle_key_press(&mut self, _ctx: &NodeContext, _args: Event<KeyPress>) {
         self.content.set("Key Press".to_string());
     }
 
-    pub fn handle_click(&mut self, _ctx: &NodeContext, _args: ArgsClick) {
+    pub fn handle_click(&mut self, _ctx: &NodeContext, _args: Event<Click>) {
         self.content.set("Click".to_string());
     }
 
-    pub fn handle_double_click(&mut self, _ctx: &NodeContext, _args: ArgsDoubleClick) {
+    pub fn handle_double_click(&mut self, _ctx: &NodeContext, _args: Event<DoubleClick>) {
         self.content.set("Double Click".to_string());
     }
 
-    pub fn handle_mouse_move(&mut self, _ctx: &NodeContext, _args: ArgsMouseMove) {
+    pub fn handle_mouse_move(&mut self, _ctx: &NodeContext, _args: Event<MouseMove>) {
         self.content.set("Mouse Move".to_string());
     }
 
-    pub fn handle_wheel(&mut self, _ctx: &NodeContext, _args: ArgsWheel) {
+    pub fn handle_wheel(&mut self, _ctx: &NodeContext, _args: Event<Wheel>) {
         self.content.set("Wheel".to_string());
     }
 
-    pub fn handle_mouse_down(&mut self, _ctx: &NodeContext, _args: ArgsMouseDown) {
+    pub fn handle_mouse_down(&mut self, _ctx: &NodeContext, _args: Event<MouseDown>) {
         self.content.set("Mouse Down".to_string());
     }
 
-    pub fn handle_mouse_up(&mut self, _ctx: &NodeContext, _args: ArgsMouseUp) {
+    pub fn handle_mouse_up(&mut self, _ctx: &NodeContext, _args: Event<MouseUp>) {
         self.content.set("Mouse Up".to_string());
     }
 
-    pub fn handle_mouse_over(&mut self, _ctx: &NodeContext, _args: ArgsMouseOver) {
+    pub fn handle_mouse_over(&mut self, _ctx: &NodeContext, _args: Event<MouseOver>) {
         self.content.set("Mouse Over".to_string());
     }
 
-    pub fn handle_mouse_out(&mut self, _ctx: &NodeContext, _args: ArgsMouseOut) {
+    pub fn handle_mouse_out(&mut self, _ctx: &NodeContext, _args: Event<MouseOut>) {
         self.content.set("Mouse Out".to_string());
     }
 
-    pub fn handle_context_menu(&mut self, _ctx: &NodeContext, _args: ArgsContextMenu){
+    pub fn handle_context_menu(&mut self, _ctx: &NodeContext, _args: Event<ContextMenu>) {
         self.content.set("Context Menu".to_string());
     }
 }

--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -21,9 +21,7 @@ use pax_runtime::{ExpressionTable, PaxEngine, Renderer};
 //Note that any types exposed by pax_message must ALSO be added to `PaxCartridge.h`
 //in order to be visible to Swift
 pub use pax_message::*;
-use pax_runtime::api::{
-    ArgsClick, ArgsScroll, ModifierKey, MouseButton, MouseEventArgs, RenderContext,
-};
+use pax_runtime::api::{Click, ModifierKey, MouseButton, MouseEventArgs, RenderContext};
 
 /// Container data structure for PaxEngine, aggregated to support passing across C bridge
 #[repr(C)] //Exposed to Swift via PaxCartridge.h
@@ -103,7 +101,7 @@ pub extern "C" fn pax_interrupt(
                         .iter()
                         .map(|x| ModifierKey::from(x))
                         .collect();
-                    let args_click = ArgsClick {
+                    let args_click = Click {
                         mouse: MouseEventArgs {
                             x: args.x,
                             y: args.y,

--- a/pax-chassis-web/interface/src/classes/native-element-pool.ts
+++ b/pax-chassis-web/interface/src/classes/native-element-pool.ts
@@ -215,6 +215,7 @@ export class NativeElementPool {
         runningChain.appendChild(textbox);
         runningChain.setAttribute("class", NATIVE_LEAF_CLASS)
         runningChain.setAttribute("id_chain", String(patch.idChain));
+
         let scroller_id;
         if(patch.scrollerIds != null){
             let length = patch.scrollerIds.length;
@@ -396,6 +397,7 @@ export class NativeElementPool {
                 scroller_id = patch.scrollerIds[length-1];
             }
         }
+        textChild.style.userSelect = "none";
 
         if(patch.idChain != undefined && patch.zIndex != undefined) {
             NativeElementPool.addNativeElement(runningChain, this.baseOcclusionContext,
@@ -414,7 +416,6 @@ export class NativeElementPool {
         console.assert(leaf !== undefined);
 
         let textChild = leaf.firstChild;
-
         // Handle size_x and size_y
         if (patch.size_x != null) {
             leaf.style.width = patch.size_x + "px";

--- a/pax-chassis-web/interface/src/events/listeners.ts
+++ b/pax-chassis-web/interface/src/events/listeners.ts
@@ -159,7 +159,10 @@ export function setupEventListeners(chassis: PaxChassisWeb) {
                 "modifiers": convertModifiers(evt)
             }
         };
-        chassis.interrupt(JSON.stringify(event), []);
+        let res = chassis.interrupt(JSON.stringify(event), []);
+        if (res.prevent_default) {
+            evt.preventDefault();
+        }
     }, true);
     // @ts-ignore
     window.addEventListener('touchstart', (evt) => {

--- a/pax-chassis-web/interface/src/types/pax-chassis-web.d.ts
+++ b/pax-chassis-web/interface/src/types/pax-chassis-web.d.ts
@@ -42,7 +42,7 @@ export class PaxChassisWeb {
 * @param {string} native_interrupt
 * @param {any} additional_payload
 */
-  interrupt(native_interrupt: string, additional_payload: any): void;
+  interrupt(native_interrupt: string, additional_payload: any): InterruptResult;
 /**
 * @param {MemorySlice} slice
 */
@@ -57,6 +57,10 @@ export class PaxChassisWeb {
 }
 
 export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+export interface InterruptResult {
+  readonly prevent_default: boolean;  
+}
 
 export interface InitOutput {
   readonly memory: WebAssembly.Memory;

--- a/pax-compiler/new-libdev-project-template/src/lib.rs
+++ b/pax-compiler/new-libdev-project-template/src/lib.rs
@@ -1,12 +1,12 @@
 #![allow(unused_imports)]
 
-use pax_engine::*;
 use pax_engine::api::*;
-use pax_std::primitives::*;
-use pax_std::types::*;
-use pax_std::types::text::*;
-use pax_std::components::*;
+use pax_engine::*;
 use pax_std::components::Stacker;
+use pax_std::components::*;
+use pax_std::primitives::*;
+use pax_std::types::text::*;
+use pax_std::types::*;
 
 #[pax]
 #[main]
@@ -26,9 +26,10 @@ impl Example {
         self.ticks.set(old_ticks + 1);
     }
 
-    pub fn increment(&mut self, ctx: &NodeContext, args: ArgsClick){
+    pub fn increment(&mut self, ctx: &NodeContext, args: Event<Click>) {
         let old_num_clicks = self.num_clicks.get();
         self.num_clicks.set(old_num_clicks + 1);
-        self.message.set(format!("{} clicks", self.num_clicks.get()));
+        self.message
+            .set(format!("{} clicks", self.num_clicks.get()));
     }
 }

--- a/pax-compiler/new-project-template/src/lib.rs
+++ b/pax-compiler/new-project-template/src/lib.rs
@@ -1,12 +1,12 @@
 #![allow(unused_imports)]
 
-use pax_engine::*;
 use pax_engine::api::*;
-use pax_std::primitives::*;
-use pax_std::types::*;
-use pax_std::types::text::*;
-use pax_std::components::*;
+use pax_engine::*;
 use pax_std::components::Stacker;
+use pax_std::components::*;
+use pax_std::primitives::*;
+use pax_std::types::text::*;
+use pax_std::types::*;
 
 #[pax]
 #[main]
@@ -26,9 +26,10 @@ impl Example {
         self.ticks.set(old_ticks + 1);
     }
 
-    pub fn increment(&mut self, ctx: &NodeContext, args: ArgsClick){
+    pub fn increment(&mut self, ctx: &NodeContext, args: Event<Click>) {
         let old_num_clicks = self.num_clicks.get();
         self.num_clicks.set(old_num_clicks + 1);
-        self.message.set(format!("{} clicks", self.num_clicks.get()));
+        self.message
+            .set(format!("{} clicks", self.num_clicks.get()));
     }
 }

--- a/pax-compiler/src/lib.rs
+++ b/pax-compiler/src/lib.rs
@@ -80,22 +80,22 @@ pub fn perform_build(ctx: &RunContext) -> eyre::Result<(PaxManifest, Option<Path
         let mut cmd = Command::new("./build-interface.sh");
         if let Ok(root) = std::env::var("PAX_WORKSPACE_ROOT") {
             let chassis_web_path = Path::new(&root).join("pax-chassis-web");
-            cmd.current_dir(&chassis_web_path)
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped());
+            cmd.current_dir(&chassis_web_path);
             if !cmd
                 .output()
                 .expect("failed to start process")
                 .status
                 .success()
             {
-                eprintln!(
+                panic!(
                     "failed to build js files running ./build-interface.sh at {:?}",
                     chassis_web_path
                 );
             };
         } else {
-            eprintln!("Warning: PAX_WORKSPACE_ROOT env variable not set - didn't compile typescript files");
+            panic!(
+                "FATAL: PAX_WORKSPACE_ROOT env variable not set - didn't compile typescript files"
+            );
         }
     }
 

--- a/pax-manifest/src/cartridge_generation/mod.rs
+++ b/pax-manifest/src/cartridge_generation/mod.rs
@@ -54,27 +54,27 @@ impl PaxManifest {
         let mut add = |from: &str, to: &str| {
             map.insert(from.to_owned(), Some(to.to_owned()));
         };
-        add("scroll", "ArgsScroll");
-        add("clap", "ArgsClap");
-        add("touch_start", "ArgsTouchStart");
-        add("touch_move", "ArgsTouchMove");
-        add("touch_end", "ArgsTouchEnd");
-        add("key_down", "ArgsKeyDown");
-        add("key_up", "ArgsKeyUp");
-        add("key_press", "ArgsKeyPress");
-        add("checkbox_change", "ArgsCheckboxChange");
-        add("button_click", "ArgsButtonClick");
-        add("textbox_change", "ArgsTextboxChange");
-        add("textbox_input", "ArgsTextboxInput");
-        add("click", "ArgsClick");
-        add("mouse_down", "ArgsMouseDown");
-        add("mouse_up", "ArgsMouseUp");
-        add("mouse_move", "ArgsMouseMove");
-        add("mouse_over", "ArgsMouseOver");
-        add("mouse_out", "ArgsMouseOut");
-        add("double_click", "ArgsDoubleClick");
-        add("context_menu", "ArgsContextMenu");
-        add("wheel", "ArgsWheel");
+        add("scroll", "Scroll");
+        add("clap", "Clap");
+        add("touch_start", "TouchStart");
+        add("touch_move", "TouchMove");
+        add("touch_end", "TouchEnd");
+        add("key_down", "KeyDown");
+        add("key_up", "KeyUp");
+        add("key_press", "KeyPress");
+        add("checkbox_change", "CheckboxChange");
+        add("button_click", "ButtonClick");
+        add("textbox_change", "TextboxChange");
+        add("textbox_input", "TextboxInput");
+        add("click", "Click");
+        add("mouse_down", "MouseDown");
+        add("mouse_up", "MouseUp");
+        add("mouse_move", "MouseMove");
+        add("mouse_over", "MouseOver");
+        add("mouse_out", "MouseOut");
+        add("double_click", "DoubleClick");
+        add("context_menu", "ContextMenu");
+        add("wheel", "Wheel");
         map.insert("pre_render".to_string(), None);
         map.insert("mount".to_string(), None);
         map.insert("tick".to_string(), None);
@@ -111,7 +111,11 @@ impl PaxManifest {
                 for setting in settings {
                     if let SettingsBlockElement::Handler(key, values) = setting {
                         for value in values {
-                            let args_type = event_map.get(key.token_value.as_str()).unwrap();
+                            let args_type = event_map
+                                .get(key.token_value.as_str())
+                                .unwrap()
+                                .as_ref()
+                                .map(|t| format!("Event<{}>", &t));
                             handler_data.push(HandlerInfo {
                                 name: self.clean_handler(value.raw_value.clone()),
                                 args_type: args_type.clone(),
@@ -130,7 +134,9 @@ impl PaxManifest {
                                 if let ValueDefinition::EventBindingTarget(e) = value {
                                     let args_type = event_map
                                         .get(key.token_value.as_str())
-                                        .expect("Unsupported event");
+                                        .expect("Unsupported event")
+                                        .as_ref()
+                                        .map(|t| format!("Event<{}>", &t));
                                     handler_data.push(HandlerInfo {
                                         name: self.clean_handler(e.raw_value.clone()),
                                         args_type: args_type.clone(),

--- a/pax-manifest/src/lib.rs
+++ b/pax-manifest/src/lib.rs
@@ -842,6 +842,9 @@ impl ComponentTemplate {
                     children.retain(|child| *child != node);
                 }
             }
+            self.nodes.remove(&id);
+            self.children.remove(&id);
+            self.root.retain(|child| *child != id);
             node
         } else {
             panic!("Requested node doesn't exist in template");

--- a/pax-runtime/src/engine/mod.rs
+++ b/pax-runtime/src/engine/mod.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use pax_message::{NativeMessage, OcclusionPatch};
 
 use crate::api::{
-    ArgsKeyDown, ArgsKeyPress, ArgsKeyUp, CommonProperties, Interpolatable, Layer, NodeContext,
+    CommonProperties, Interpolatable, KeyDown, KeyPress, KeyUp, Layer, NodeContext,
     OcclusionLayerGen, RenderContext, TransitionManager,
 };
 use piet::InterpolationMode;
@@ -418,40 +418,40 @@ impl PaxEngine {
         self.runtime_context.globals_mut().viewport.bounds = new_viewport_size;
     }
 
-    pub fn global_dispatch_key_down(&self, args: ArgsKeyDown) {
+    pub fn global_dispatch_key_down(&self, args: KeyDown) {
         self.root_node.recurse_visit_postorder(
             &|expanded_node, _| {
                 expanded_node.dispatch_key_down(
                     args.clone(),
                     self.runtime_context.globals(),
                     &self.runtime_context,
-                )
+                );
             },
             &mut (),
         );
     }
 
-    pub fn global_dispatch_key_up(&self, args: ArgsKeyUp) {
+    pub fn global_dispatch_key_up(&self, args: KeyUp) {
         self.root_node.recurse_visit_postorder(
             &|expanded_node, _| {
                 expanded_node.dispatch_key_up(
                     args.clone(),
                     self.runtime_context.globals(),
                     &self.runtime_context,
-                )
+                );
             },
             &mut (),
         );
     }
 
-    pub fn global_dispatch_key_press(&self, args: ArgsKeyPress) {
+    pub fn global_dispatch_key_press(&self, args: KeyPress) {
         self.root_node.recurse_visit_postorder(
             &|expanded_node, _| {
                 expanded_node.dispatch_key_press(
                     args.clone(),
                     self.runtime_context.globals(),
                     &self.runtime_context,
-                )
+                );
             },
             &mut (),
         );

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -11,7 +11,7 @@ use crate::node_interface::NodeLocal;
 use pax_manifest::UniqueTemplateNodeIdentifier;
 use piet::{Color, StrokeStyle};
 
-use crate::api::{ArgsScroll, Layer, Size};
+use crate::api::{Layer, Scroll, Size};
 
 use crate::{ExpandedNode, ExpressionTable, Globals, HandlerRegistry, RuntimeContext};
 
@@ -235,7 +235,7 @@ pub trait InstanceNode {
     }
     /// Invoked by event interrupts to pass scroll information to render node
     #[allow(unused_variables)]
-    fn handle_scroll(&self, args_scroll: ArgsScroll) {
+    fn handle_scroll(&self, args_scroll: Scroll) {
         //no-op default implementation
     }
 }


### PR DESCRIPTION
This does a light refactor on events.

What before was ArgsClick is now Click, and all events come wrapped in the Event<T> type.

Event<T> has a function prevent_default(), that prevents default browser/native behaviour if triggered.